### PR TITLE
Fix deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,23 +100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
 dependencies = [
  "bitflags",
- "crossterm_winapi 0.8.0",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
-dependencies = [
- "bitflags",
- "crossterm_winapi 0.9.0",
+ "crossterm_winapi",
  "libc",
  "mio",
  "parking_lot",
@@ -135,24 +119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm_winapi"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,17 +126,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1113,7 +1068,7 @@ checksum = "39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm 0.20.0",
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1124,13 +1079,11 @@ version = "1.4.0"
 dependencies = [
  "anyhow",
  "chrono",
- "crossterm 0.22.1",
- "dirs",
+ "crossterm",
  "futures",
  "indexmap",
  "irc",
  "lazy_static",
- "rand",
  "rustyline",
  "serde",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,9 @@ keywords = ["tui", "twitch"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-crossterm = "0.22.1"
+crossterm = "0.20.0"
 tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
 anyhow = "1.0.48"
-rand = "0.8.4"
 unicode-width = "0.1.9"
 unicode-segmentation = "1.8.0"
 chrono = "0.4"
@@ -25,7 +24,6 @@ tokio = { version = "1.14.0", features = ["full"] }
 toml = "0.5.8"
 serde = { version = "1.0.130", features = ["derive"] }
 textwrap = "0.14.2"
-dirs = "4.0.0"
 rustyline = "9.0.0"
 lazy_static = "1.4.0"
 indexmap = "1.7.0"


### PR DESCRIPTION
Remove unneeded and duplicated dependencies. Not a big improvement, but a little clear of `Cargo.toml`.

Set version of `crossterm` from `tui`