### PR TITLE
Add parse cli args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+
+[[package]]
 name = "pin-project"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1136,7 @@ dependencies = [
  "indexmap",
  "irc",
  "lazy_static",
+ "pico-args",
  "rand",
  "rustyline",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dirs = "4.0.0"
 rustyline = "9.0.0"
 lazy_static = "1.4.0"
 indexmap = "1.7.0"
+pico-args = "0.4.2"
 
 [[bin]]
 bench = false


### PR DESCRIPTION
Add parsing cli arguments.

- add pico-args crate
- add parsing twitch channel

Examples:
```
$ cargo run -q -- -h
twitch-tui

USAGE:
  app [OPTIONS]
FLAGS:
  -h, --help            Prints help information
OPTIONS:
  --channel CHANNEL     Sets a channel(the streamer's name)
```

```
$ cargo run -q -- --channel dogdog
```