### PR TITLE
Add clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -64,6 +84,21 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -920,6 +955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +983,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1079,6 +1129,7 @@ version = "1.4.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "crossterm",
  "futures",
  "indexmap",
@@ -1086,7 +1137,7 @@ dependencies = [
  "lazy_static",
  "rustyline",
  "serde",
- "textwrap",
+ "textwrap 0.14.2",
  "tokio",
  "toml",
  "tui",
@@ -1132,6 +1183,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ textwrap = "0.14.2"
 rustyline = "9.0.0"
 lazy_static = "1.4.0"
 indexmap = "1.7.0"
+clap = "2.33.3"
 
 [[bin]]
 bench = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-extern crate clap;
-
 use anyhow::Result;
 use tokio::sync::mpsc;
 
@@ -22,26 +20,26 @@ async fn main() -> Result<()> {
         .args_from_usage("-c, --channel=[CHANNEL] 'The streamer's name'
                           -t, --tick-delay=[DELAY] 'The delay in milliseconds between terminal updates'
                           -m, --max-messages=[MESSAGES] 'The maximum amount of messages to be stored'
-                          -s, --date-shown=[true/false] 'If the time and date is to be shown'
-                          -u, --maximum-username-length=[LENGTH] 'The longest a username can be'
+                          -s, --date-shown=[true/false] 'If the time and date is to be shown (defaults to true)'
+                          -u, --maximum-username-length=[LENGTH] 'Maximum length for Twitch usernames'
                           -a, --username-alignment=[left/center/right] 'Side the username should be aligned to'
                           -p, --palette=[PALETTE] 'The color palette for the username column: pastel (default), vibrant, warm, cool'")
         .get_matches();
 
     match CompleteConfig::new() {
         Ok(mut config) => {
-            // twitch section of config
+            // Twitch section of the config
             if let Some(ch) = arg_matches.value_of("channel") {
                 config.twitch.channel = ch.to_string();
             }
-            // terminal section of config
+            // Terminal section of the config
             if let Some(tick_delay) = arg_matches.value_of("tick-delay") {
                 config.terminal.tick_delay = tick_delay.parse().unwrap();
             }
             if let Some(max_messages) = arg_matches.value_of("maximum-messages") {
                 config.terminal.maximum_messages = max_messages.parse().unwrap();
             }
-            // frontend section of config
+            // Frontend section of the config
             if let Some(date_shown) = arg_matches.value_of("date-shown") {
                 config.frontend.date_shown = date_shown.parse().unwrap();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
                           -t, --tick-delay=[DELAY] 'The delay in milliseconds between terminal updates'
                           -m, --max-messages=[MESSAGES] 'The maximum amount of messages to be stored'
                           -s, --date-shown=[true/false] 'If the time and date is to be shown (defaults to true)'
-                          -u, --maximum-username-length=[LENGTH] 'Maximum length for Twitch usernames'
+                          -u, --max-username-length=[LENGTH] 'Maximum length for Twitch usernames'
                           -a, --username-alignment=[left/center/right] 'Side the username should be aligned to'
                           -p, --palette=[PALETTE] 'The color palette for the username column: pastel (default), vibrant, warm, cool'")
         .get_matches();
@@ -36,14 +36,14 @@ async fn main() -> Result<()> {
             if let Some(tick_delay) = arg_matches.value_of("tick-delay") {
                 config.terminal.tick_delay = tick_delay.parse().unwrap();
             }
-            if let Some(max_messages) = arg_matches.value_of("maximum-messages") {
+            if let Some(max_messages) = arg_matches.value_of("max-messages") {
                 config.terminal.maximum_messages = max_messages.parse().unwrap();
             }
             // Frontend section of the config
             if let Some(date_shown) = arg_matches.value_of("date-shown") {
                 config.frontend.date_shown = date_shown.parse().unwrap();
             }
-            if let Some(maximum_username_length) = arg_matches.value_of("maximum-username-length") {
+            if let Some(maximum_username_length) = arg_matches.value_of("max-username-length") {
                 config.frontend.maximum_username_length = maximum_username_length.parse().unwrap();
             }
             if let Some(username_alignment) = arg_matches.value_of("username-alignment") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
+extern crate clap;
+
 use anyhow::Result;
 use tokio::sync::mpsc;
 
-use handlers::config::CompleteConfig;
+use handlers::config::{CompleteConfig, Palette};
 
 use crate::handlers::app::App;
 
@@ -13,8 +15,51 @@ mod utils;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let arg_matches = clap::App::new("twitch-tui")
+        .version("1.4.1")
+        .author("Xithrius")
+        .about("Twitch chat in the terminal.")
+        .args_from_usage("-c, --channel=[CHANNEL] 'The streamer's name'
+                          -t, --tick-delay=[DELAY] 'The delay in milliseconds between terminal updates'
+                          -m, --max-messages=[MESSAGES] 'The maximum amount of messages to be stored'
+                          -s, --date-shown=[true/false] 'If the time and date is to be shown'
+                          -u, --maximum-username-length=[LENGTH] 'The longest a username can be'
+                          -a, --username-alignment=[left/center/right] 'Side the username should be aligned to'
+                          -p, --palette=[PALETTE] 'The color palette for the username column: pastel (default), vibrant, warm, cool'")
+        .get_matches();
+
     match CompleteConfig::new() {
-        Ok(config) => {
+        Ok(mut config) => {
+            // twitch section of config
+            if let Some(ch) = arg_matches.value_of("channel") {
+                config.twitch.channel = ch.to_string();
+            }
+            // terminal section of config
+            if let Some(tick_delay) = arg_matches.value_of("tick-delay") {
+                config.terminal.tick_delay = tick_delay.parse().unwrap();
+            }
+            if let Some(max_messages) = arg_matches.value_of("maximum-messages") {
+                config.terminal.maximum_messages = max_messages.parse().unwrap();
+            }
+            // frontend section of config
+            if let Some(date_shown) = arg_matches.value_of("date-shown") {
+                config.frontend.date_shown = date_shown.parse().unwrap();
+            }
+            if let Some(maximum_username_length) = arg_matches.value_of("maximum-username-length") {
+                config.frontend.maximum_username_length = maximum_username_length.parse().unwrap();
+            }
+            if let Some(username_alignment) = arg_matches.value_of("username-alignment") {
+                config.frontend.username_alignment = username_alignment.to_string();
+            }
+            if let Some(palette) = arg_matches.value_of("palette") {
+                config.frontend.palette = match palette {
+                    "vibrant" => Palette::Vibrant,
+                    "warm" => Palette::Warm,
+                    "cool" => Palette::Cool,
+                    _ => Palette::Pastel,
+                };
+            }
+
             let app = App::new(config.clone());
 
             let (twitch_tx, terminal_rx) = mpsc::channel(100);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -97,9 +97,9 @@ pub async fn ui_driver(
 
     'outer: loop {
         terminal
-            .draw(|mut frame| match app.state {
-                State::Help => draw_keybinds_ui(&mut frame).unwrap(),
-                _ => draw_chat_ui(&mut frame, &mut app, &config).unwrap(),
+            .draw(|frame| match app.state {
+                State::Help => draw_keybinds_ui(frame).unwrap(),
+                _ => draw_chat_ui(frame, &mut app, &config).unwrap(),
             })
             .unwrap();
 

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -11,18 +11,12 @@ pub fn align_text(text: &str, alignment: &str, maximum_length: u16) -> String {
 
     match alignment {
         "left" => text.to_string(),
-        "right" => format!(
-            "{}{}",
-            " ".repeat((maximum_length - text.len() as u16) as usize),
-            text
-        ),
-        "center" => {
-            let side_spaces = " ".repeat(
-                ((maximum_length / 2) - (((text.len() / 2) as f32).floor() as u16)) as usize,
-            );
-
-            format!("{}{}{}", side_spaces, text, side_spaces)
-        }
+        "right" => format!("{text:>width$}",
+                           text=text,
+                           width=std::cmp::max(maximum_length, text.len() as u16) as usize),
+        "center" => format!("{text:^width$}",
+                           text=text,
+                           width=std::cmp::max(maximum_length, text.len() as u16) as usize),
         _ => text.to_string(),
     }
 }
@@ -109,7 +103,7 @@ mod tests {
     #[test]
     fn test_text_align_center() {
         assert_eq!(
-            align_text("a", "center", 10),
+            align_text("a", "center", 11),
             format!("{}{}{}", " ".repeat(5), "a", " ".repeat(5))
         );
         assert_eq!(align_text("a", "center", 1), "a".to_string());

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -11,12 +11,16 @@ pub fn align_text(text: &str, alignment: &str, maximum_length: u16) -> String {
 
     match alignment {
         "left" => text.to_string(),
-        "right" => format!("{text:>width$}",
-                           text=text,
-                           width=std::cmp::max(maximum_length, text.len() as u16) as usize),
-        "center" => format!("{text:^width$}",
-                           text=text,
-                           width=std::cmp::max(maximum_length, text.len() as u16) as usize),
+        "right" => format!(
+            "{text:>width$}",
+            text = text,
+            width = std::cmp::max(maximum_length, text.len() as u16) as usize
+        ),
+        "center" => format!(
+            "{text:^width$}",
+            text = text,
+            width = std::cmp::max(maximum_length, text.len() as u16) as usize
+        ),
         _ => text.to_string(),
     }
 }


### PR DESCRIPTION
Add parsing cli arguments by `clap` crate.

Add parsing some vars from config:
- twitch channel
- tick delay
- max messages
- date shown
- maximum username length
- username alignment
- palette

Example:
```
Running `target/debug/twt -h`
twitch-tui 1.4.1
Xithrius
Twitch chat in the terminal.

USAGE:
    twt [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -c, --channel <CHANNEL>                         The streamer's name
    -s, --date-shown <true/false>                   If the time and date is to be shown
    -m, --max-messages <MESSAGES>                   The maximum amount of messages to be stored
    -u, --maximum-username-length <LENGTH>          The longest a username can be
    -p, --palette <PALETTE>
            The color palette for the username column: pastel (default), vibrant, warm, cool

    -t, --tick-delay <DELAY>                        The delay in milliseconds between terminal updates
    -a, --username-alignment <left/center/right>    Side the username should be aligned to
```

Fix issue with text alignment. Now column with `Username` crop without error(maybe add some minimal value of crop, length of string `Username` or max value of any username in chat).
