### PR TITLE
Message filtering with regex, channel/mention/command suggestions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
  "os_str_bytes",
  "strsim",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap",
 ]
 
 [[package]]
@@ -1204,15 +1204,6 @@ dependencies = [
 name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-<<<<<<< HEAD
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-=======
->>>>>>> 1ef28eb (winsqlite3 feature now targets only Windows)
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 dependencies = [
  "smawk",
@@ -1364,7 +1355,7 @@ dependencies = [
  "rusqlite",
  "rustyline",
  "serde",
- "textwrap 0.15.0",
+ "textwrap",
  "tokio",
  "toml",
  "tui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d76c22c9b9b215eeb8d016ad3a90417bd13cb24cf8142756e6472445876cab7"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -96,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -318,6 +329,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcef756dea9cf3db5ce73759cf0467330427a786b47711b8d6c97620d718ceb9"
+checksum = "02ecad9808e0596f8956d14f7fa868f996290bd01c8d7329d6e5bc2bb76adf8f"
 dependencies = [
  "cfg-if",
  "rustix",
@@ -452,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -466,6 +489,18 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
@@ -503,12 +538,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.4.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
-dependencies = [
- "winapi",
-]
+checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 
 [[package]]
 name = "irc"
@@ -560,10 +592,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.0.37"
+name = "libsqlite3-sys"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f5690fef754d905294c56f7ac815836f2513af966aa47f2e07ac79be07827f"
+checksum = "d2cafc7c74096c336d9d27145f7ebd4f4b6f95ba16aa5a282387267e6925cb58"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "lock_api"
@@ -943,10 +985,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.32.1"
+name = "rusqlite"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cee647393af53c750e15dcbf7781cdd2e550b246bde76e46c326e7ea3c73773"
+checksum = "4ba4d3462c8b2e4d7f4fcfcf2b296dc6b65404fbbc7b63daa37fd485c149daf7"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "0.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9466f25b92a648960ac1042fd3baa6b0bf285e60f754d7e5070770c813a177a"
 dependencies = [
  "bitflags",
  "errno",
@@ -1300,6 +1357,8 @@ dependencies = [
  "fuzzy-matcher",
  "irc",
  "lazy_static",
+ "regex",
+ "rusqlite",
  "rustyline",
  "serde",
  "textwrap 0.15.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.2"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
+checksum = "ced1892c55c910c1219e98d6fc8d71f6bddba7905866ce740066d8bfea859312"
 dependencies = [
  "atty",
  "bitflags",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -593,9 +593,9 @@ checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cafc7c74096c336d9d27145f7ebd4f4b6f95ba16aa5a282387267e6925cb58"
+checksum = "4b8f2caab464860c64cdf0a7435d36906e25894b67e774b5dd44146ef1cd0420"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "openssl"
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.26.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba4d3462c8b2e4d7f4fcfcf2b296dc6b65404fbbc7b63daa37fd485c149daf7"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -1193,23 +1193,26 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+<<<<<<< HEAD
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+=======
+>>>>>>> 1ef28eb (winsqlite3 feature now targets only Windows)
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 dependencies = [
  "smawk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "twitch-tui"
 version = "2.0.0-alpha.1"
 authors = ["Xithrius <xithrius@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.58.1"
 description = "Twitch chat in the terminal."
 documentation = "https://github.com/Xithrius/twitch-tui"
 homepage = "https://github.com/Xithrius/twitch-tui"
@@ -29,6 +30,8 @@ rustyline = "9.1.2"
 lazy_static = "1.4.0"
 enum-iterator = "0.7.0"
 fuzzy-matcher = "0.3.7"
+rusqlite = "0.26.3"
+regex = "1.5.4"
 
 [[bin]]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,11 @@ rustyline = "9.1.2"
 lazy_static = "1.4.0"
 enum-iterator = "0.7.0"
 fuzzy-matcher = "0.3.7"
-rusqlite = "0.26.3"
+rusqlite = "0.27.0"
 regex = "1.5.4"
+
+[target.'cfg(windows)'.dependencies]
+rusqlite = { version = "0.27.0", features = ["winsqlite3"] }
 
 [[bin]]
 bench = false

--- a/default-config.toml
+++ b/default-config.toml
@@ -25,9 +25,17 @@ maximum_username_length = 26
 username_alignment = "right"
 # The color palette for the username column: pastel (default), vibrant, warm, cool.
 palette = "pastel"
-# Show title
+# Show title with time and channel.
 title_shown = true
-# Show padding around chat frame
+# Show padding around chat frame.
 padding = true
-# Show twitch badges
+# Show twitch badges next to usernames.
 badges = true
+
+[database]
+# If filters should be enabled at all.
+filters = true
+# If previous channels switched to should be tracked.
+channels = true
+# If previous username mentions should be tracked.
+mentions = true

--- a/default-config.toml
+++ b/default-config.toml
@@ -14,6 +14,18 @@ tick_delay = 30
 # The maximum amount of messages to be stored.
 maximum_messages = 150
 
+[database]
+# If previous channels switched to should be tracked.
+channels = true
+# If previous username mentions should be tracked.
+mentions = true
+
+[filters]
+# If filters should be enabled at all.
+enabled = true
+# If the regex filters should be reversed
+reversed = true
+
 [frontend]
 # If the time and date is to be shown.
 date_shown = true
@@ -31,11 +43,3 @@ title_shown = true
 padding = true
 # Show twitch badges next to usernames.
 badges = true
-
-[database]
-# If filters should be enabled at all.
-filters = true
-# If previous channels switched to should be tracked.
-channels = true
-# If previous username mentions should be tracked.
-mentions = true

--- a/src/handlers/app.rs
+++ b/src/handlers/app.rs
@@ -9,7 +9,10 @@ use rusqlite::Connection as SqliteConnection;
 use rustyline::line_buffer::LineBuffer;
 use tui::layout::Constraint;
 
-use crate::handlers::{config::CompleteConfig, data::Data, database::Database};
+use crate::{
+    handlers::{config::CompleteConfig, data::Data, database::Database, filters::Filters},
+    utils::pathing::config_path,
+};
 
 pub enum State {
     Normal,
@@ -27,21 +30,23 @@ pub enum BufferName {
 }
 
 pub struct App {
-    /// History of recorded messages (time, username, message)
+    /// History of recorded messages (time, username, message).
     pub messages: VecDeque<Data>,
     /// Connection to the sqlite3 database.
     pub database: Database,
-    /// Postgres database client
+    /// Filtering out messages, no usernames since Twitch does that themselves.
+    pub filters: Filters,
+    /// Which window the terminal is currently showing.
     pub state: State,
-    /// Which input buffer is currently selected
+    /// Which input buffer is currently selected.
     pub selected_buffer: BufferName,
-    /// Current value of the input box
+    /// Current value of the input box.
     pub input_buffers: HashMap<BufferName, LineBuffer>,
-    /// The constraints that are set on the table
+    /// The constraints that are set on the table.
     pub table_constraints: Option<Vec<Constraint>>,
-    /// The titles of the columns within the table of the terminal
+    /// The titles of the columns within the table of the terminal.
     pub column_titles: Option<Vec<String>>,
-    /// Scrolling offset for windows
+    /// Scrolling offset for windows.
     pub scroll_offset: usize,
 }
 
@@ -56,6 +61,7 @@ impl App {
         Self {
             messages: VecDeque::with_capacity(config.terminal.maximum_messages),
             database: Database::new(database_connection),
+            filters: Filters::new(config_path("filters.txt"), config.filters),
             state: State::Normal,
             selected_buffer: BufferName::Chat,
             input_buffers: input_buffers_map,

--- a/src/handlers/app.rs
+++ b/src/handlers/app.rs
@@ -1,10 +1,10 @@
-use std::collections::{HashMap, VecDeque};
-
 use enum_iterator::IntoEnumIterator;
+use rusqlite::Connection as SqliteConnection;
 use rustyline::line_buffer::LineBuffer;
+use std::collections::{HashMap, VecDeque};
 use tui::layout::Constraint;
 
-use crate::handlers::{config::CompleteConfig, data::Data};
+use crate::handlers::{config::CompleteConfig, data::Data, database::Database};
 
 pub enum State {
     Normal,
@@ -24,7 +24,9 @@ pub enum BufferName {
 pub struct App {
     /// History of recorded messages (time, username, message)
     pub messages: VecDeque<Data>,
-    /// Which window the terminal is currently showing
+    /// Connection to the sqlite3 database.
+    pub db: Database,
+    /// Postgres database client
     pub state: State,
     /// Which input buffer is currently selected
     pub selected_buffer: BufferName,
@@ -39,7 +41,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(config: CompleteConfig) -> Self {
+    pub fn new(config: CompleteConfig, database_connection: SqliteConnection) -> Self {
         let mut input_buffers_map = HashMap::new();
 
         for name in BufferName::into_enum_iter() {
@@ -48,6 +50,7 @@ impl App {
 
         Self {
             messages: VecDeque::with_capacity(config.terminal.maximum_messages),
+            db: Database::new(database_connection),
             state: State::Normal,
             selected_buffer: BufferName::Chat,
             input_buffers: input_buffers_map,

--- a/src/handlers/app.rs
+++ b/src/handlers/app.rs
@@ -40,6 +40,8 @@ pub struct App {
     pub state: State,
     /// Which input buffer is currently selected.
     pub selected_buffer: BufferName,
+    /// The current suggestion for a specific buffer.
+    pub buffer_suggestion: String,
     /// Current value of the input box.
     pub input_buffers: HashMap<BufferName, LineBuffer>,
     /// The constraints that are set on the table.
@@ -64,6 +66,7 @@ impl App {
             filters: Filters::new(config_path("filters.txt"), config.filters),
             state: State::Normal,
             selected_buffer: BufferName::Chat,
+            buffer_suggestion: "".to_string(),
             input_buffers: input_buffers_map,
             table_constraints: None,
             column_titles: None,

--- a/src/handlers/app.rs
+++ b/src/handlers/app.rs
@@ -1,7 +1,12 @@
+use std::{
+    cmp::Eq,
+    collections::{HashMap, VecDeque},
+    hash::Hash,
+};
+
 use enum_iterator::IntoEnumIterator;
 use rusqlite::Connection as SqliteConnection;
 use rustyline::line_buffer::LineBuffer;
-use std::collections::{HashMap, VecDeque};
 use tui::layout::Constraint;
 
 use crate::handlers::{config::CompleteConfig, data::Data, database::Database};
@@ -14,7 +19,7 @@ pub enum State {
     MessageSearch,
 }
 
-#[derive(PartialEq, std::cmp::Eq, std::hash::Hash, IntoEnumIterator)]
+#[derive(PartialEq, Eq, Hash, IntoEnumIterator)]
 pub enum BufferName {
     Chat,
     Channel,
@@ -25,7 +30,7 @@ pub struct App {
     /// History of recorded messages (time, username, message)
     pub messages: VecDeque<Data>,
     /// Connection to the sqlite3 database.
-    pub db: Database,
+    pub database: Database,
     /// Postgres database client
     pub state: State,
     /// Which input buffer is currently selected
@@ -50,7 +55,7 @@ impl App {
 
         Self {
             messages: VecDeque::with_capacity(config.terminal.maximum_messages),
-            db: Database::new(database_connection),
+            database: Database::new(database_connection),
             state: State::Normal,
             selected_buffer: BufferName::Chat,
             input_buffers: input_buffers_map,

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -1,6 +1,7 @@
+use std::str::FromStr;
+
 use anyhow::{bail, Error, Result};
 use serde::Deserialize;
-use std::str::FromStr;
 
 use crate::utils::pathing::config_path;
 
@@ -40,6 +41,8 @@ pub struct CompleteConfig {
     pub terminal: TerminalConfig,
     /// How everything looks to the user.
     pub frontend: FrontendConfig,
+    /// If anything should be recorded for future use.
+    pub database: DatabaseConfig,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -75,12 +78,23 @@ pub struct FrontendConfig {
     /// The color palette.
     #[serde(default)]
     pub palette: Palette,
-    /// Show Title with time and channel
+    /// Show Title with time and channel.
     pub title_shown: bool,
-    /// Show padding around chat frame
+    /// Show padding around chat frame.
     pub padding: bool,
-    /// Show twitch badges
+    /// Show twitch badges next to usernames.
     pub badges: bool,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize, Clone, Debug)]
+pub struct DatabaseConfig {
+    /// If filters should be enabled at all.
+    filters: bool,
+    /// If previous channels switched to should be tracked.
+    channels: bool,
+    /// If previous username mentions should be tracked.
+    mentions: bool,
 }
 
 impl CompleteConfig {

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 use crate::utils::pathing::config_path;
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum Palette {
     Pastel,
@@ -37,19 +37,21 @@ impl Default for Palette {
     }
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct CompleteConfig {
     /// Connecting to Twitch.
     pub twitch: TwitchConfig,
     /// Internal functionality.
     pub terminal: TerminalConfig,
-    /// How everything looks to the user.
-    pub frontend: FrontendConfig,
     /// If anything should be recorded for future use.
     pub database: DatabaseConfig,
+    /// Filtering out messages.
+    pub filters: FiltersConfig,
+    /// How everything looks to the user.
+    pub frontend: FrontendConfig,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TwitchConfig {
     /// The username that this user has on Twitch.
     pub username: String,
@@ -61,7 +63,7 @@ pub struct TwitchConfig {
     pub token: String,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TerminalConfig {
     /// The delay between updates, in milliseconds.
     pub tick_delay: u64,
@@ -69,7 +71,23 @@ pub struct TerminalConfig {
     pub maximum_messages: usize,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug, Clone)]
+pub struct DatabaseConfig {
+    /// If previous channels switched to should be tracked.
+    pub channels: bool,
+    /// If previous username mentions should be tracked.
+    pub mentions: bool,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct FiltersConfig {
+    /// If filters should be enabled at all.
+    pub enabled: bool,
+    /// If the regex filters should be reversed
+    pub reversed: bool,
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct FrontendConfig {
     /// If the time and date is to be shown.
     pub date_shown: bool,
@@ -88,17 +106,6 @@ pub struct FrontendConfig {
     pub padding: bool,
     /// Show twitch badges next to usernames.
     pub badges: bool,
-}
-
-#[allow(dead_code)]
-#[derive(Deserialize, Clone, Debug)]
-pub struct DatabaseConfig {
-    /// If filters should be enabled at all.
-    filters: bool,
-    /// If previous channels switched to should be tracked.
-    channels: bool,
-    /// If previous username mentions should be tracked.
-    mentions: bool,
 }
 
 impl CompleteConfig {

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -1,7 +1,6 @@
-use std::str::FromStr;
-
 use anyhow::{bail, Error, Result};
 use serde::Deserialize;
+use std::str::FromStr;
 
 use crate::utils::pathing::config_path;
 

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -85,14 +85,14 @@ pub struct FrontendConfig {
 
 impl CompleteConfig {
     pub fn new() -> Result<Self, Error> {
-        if let Ok(config_contents) = std::fs::read_to_string(config_path()) {
+        if let Ok(config_contents) = std::fs::read_to_string(config_path("config.toml")) {
             let config: CompleteConfig = toml::from_str(config_contents.as_str()).unwrap();
 
             Ok(config)
         } else {
             bail!(
                 "Configuration not found. Create a config file at '{}', and see '{}' for an example configuration.",
-                config_path(),
+                config_path("config.toml"),
                 format!("{}/blob/main/default-config.toml", env!("CARGO_PKG_REPOSITORY"))
             )
         }

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -174,16 +174,21 @@ impl Data {
     }
 }
 
-#[test]
-fn test_username_hash() {
-    assert_eq!(
-        Data {
-            time_sent: Local::now().format("%c").to_string(),
-            author: "human".to_string(),
-            system: false,
-            payload: PayLoad::Message("beep boop".to_string()),
-        }
-        .hash_username(&Palette::Pastel),
-        Rgb(159, 223, 221)
-    );
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_username_hash() {
+        assert_eq!(
+            Data {
+                time_sent: Local::now().format("%c").to_string(),
+                author: "human".to_string(),
+                system: false,
+                payload: PayLoad::Message("beep boop".to_string()),
+            }
+            .hash_username(&Palette::Pastel),
+            Rgb(159, 223, 221)
+        );
+    }
 }

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -174,27 +174,16 @@ impl Data {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use chrono::Local;
-    use tui::style::Color::Rgb;
-
-    use super::*;
-
-    fn create_data() -> Data {
+#[test]
+fn test_username_hash() {
+    assert_eq!(
         Data {
             time_sent: Local::now().format("%c").to_string(),
             author: "human".to_string(),
             system: false,
             payload: PayLoad::Message("beep boop".to_string()),
         }
-    }
-
-    #[test]
-    fn test_username_hash() {
-        assert_eq!(
-            create_data().hash_username(&Palette::Pastel),
-            Rgb(159, 223, 221)
-        );
-    }
+        .hash_username(&Palette::Pastel),
+        Rgb(159, 223, 221)
+    );
 }

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -1,13 +1,11 @@
 use chrono::offset::Local;
-use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use lazy_static::lazy_static;
 use tui::{
     style::{Color, Color::Rgb, Modifier, Style},
     text::{Span, Spans},
     widgets::{Cell, Row},
 };
-
-use fuzzy_matcher::FuzzyMatcher;
-use lazy_static::lazy_static;
 
 use crate::{
     handlers::config::{FrontendConfig, Palette},

--- a/src/handlers/database.rs
+++ b/src/handlers/database.rs
@@ -60,16 +60,14 @@ impl Database {
     }
 
     pub fn add(&mut self, table: String, item: String) -> Result<(), Error> {
-        if TABLES.contains(&table.as_str()) {
+        if !TABLES.contains(&table.as_str()) {
             bail!("Table '{table}' does not exist within static vector tables.");
         }
 
         if let Occupied(mut m) = self.tables.entry(table.to_string()) {
             let content = &mut m.get_mut().content;
 
-            if content.contains(&item) {
-                bail!("Table '{table}' already contains item '{item}'.");
-            } else {
+            if !content.contains(&item) {
                 content.push(item.clone());
 
                 self.conn
@@ -78,12 +76,20 @@ impl Database {
                         params![item],
                     )
                     .unwrap();
-
-                Ok(())
             }
+
+            Ok(())
         } else {
             bail!("Table '{table}' for some reason doesn't exist within database tables.");
         }
+    }
+
+    pub fn get_table_content(&self, table: String) -> Result<Vec<String>, Error> {
+        if !TABLES.contains(&table.as_str()) {
+            bail!("Table '{table}' does not exist within static vector tables.");
+        }
+
+        Ok(self.tables.get(&table).unwrap().content.clone())
     }
 }
 

--- a/src/handlers/database.rs
+++ b/src/handlers/database.rs
@@ -1,27 +1,30 @@
-use regex::Regex;
-use rusqlite::Connection as SqliteConnection;
+use std::collections::{hash_map::Entry::Occupied, HashMap};
 
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
+use anyhow::{bail, Error, Result};
+use lazy_static::lazy_static;
+use rusqlite::{params, Connection as SqliteConnection};
+
+lazy_static! {
+    pub static ref TABLES: Vec<&'static str> = vec!["filters", "channels", "mentions"];
+}
+
+#[derive(Debug)]
 pub struct Database {
-    filters: DatabaseTable<Regex>,
-    channels: DatabaseTable<String>,
-    mentions: DatabaseTable<String>,
+    conn: SqliteConnection,
+    tables: HashMap<String, DatabaseTable>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
-pub struct DatabaseTable<T> {
-    raw_content: Vec<String>,
-    converted_content: Vec<T>,
-    max_track: Option<u32>,
-    enabled: bool,
+pub struct DatabaseTable {
+    content: Vec<String>,
+    _enabled: bool,
 }
 
-#[allow(dead_code)]
 impl Database {
     pub fn new(conn: SqliteConnection) -> Self {
-        let get_table_data = |conn: &SqliteConnection, table: &str| -> Vec<String> {
+        let mut tables = HashMap::new();
+
+        for table in TABLES.iter() {
             conn.execute(
                 format!(
                     "CREATE TABLE IF NOT EXISTS {} (
@@ -35,7 +38,8 @@ impl Database {
             )
             .unwrap();
 
-            conn.prepare(format!("SELECT content FROM {}", table).as_str())
+            let data = conn
+                .prepare(format!("SELECT content FROM {}", table).as_str())
                 .unwrap()
                 .query_map([], |row| {
                     let item: String = row.get(0).unwrap();
@@ -44,78 +48,47 @@ impl Database {
                 })
                 .unwrap()
                 .flatten()
-                .collect::<Vec<String>>()
-        };
+                .collect::<Vec<String>>();
 
-        let default_converter = |s: String| -> String { s };
-
-        Self {
-            filters: DatabaseTable::new(get_table_data(&conn, "filters"), |s: String| -> Regex {
-                Regex::new(&s).unwrap()
-            }),
-            channels: DatabaseTable::new(get_table_data(&conn, "channels"), default_converter),
-            mentions: DatabaseTable::new(get_table_data(&conn, "mentions"), default_converter),
+            tables.insert(table.to_string(), DatabaseTable::new(data));
         }
+
+        Self { conn, tables }
     }
 
-    pub fn dump(_conn: SqliteConnection) {
-        todo!()
+    pub fn add(&mut self, table: String, item: String) -> Result<(), Error> {
+        if TABLES.contains(&table.as_str()) {
+            bail!("Table '{table}' does not exist within static vector tables.");
+        }
+
+        if let Occupied(mut m) = self.tables.entry(table.to_string()) {
+            let content = &mut m.get_mut().content;
+
+            if content.contains(&item) {
+                bail!("Table '{table}' already contains item '{item}'.");
+            } else {
+                content.push(item.clone());
+
+                self.conn
+                    .execute(
+                        &format!("INSERT INTO {table} (content) VALUES (?1)"),
+                        params![item],
+                    )
+                    .unwrap();
+
+                Ok(())
+            }
+        } else {
+            bail!("Table '{table}' for some reason doesn't exist within database tables.");
+        }
     }
 }
 
-#[allow(dead_code)]
-impl<T> DatabaseTable<T> {
-    pub fn new<F>(raw_content: Vec<String>, converter: F) -> Self
-    where
-        F: Fn(String) -> T,
-    {
-        let converted_content = raw_content
-            .iter()
-            .map(|f| converter(f.to_string()))
-            .collect::<Vec<T>>();
-
+impl DatabaseTable {
+    pub fn new(data: Vec<String>) -> Self {
         Self {
-            raw_content,
-            converted_content,
-            max_track: None,
-            enabled: true,
+            content: data,
+            _enabled: true,
         }
-    }
-
-    fn add(&mut self, data: &str) {
-        self.raw_content.push(data.to_string());
-    }
-
-    fn remove(&mut self, data: &str) {
-        if let Some(index) = self.raw_content.iter().position(|x| x.as_str() == data) {
-            self.raw_content.remove(index);
-        }
-    }
-
-    fn edit(&mut self, data_old: &str, data_new: &str) {
-        self.remove(data_old);
-        self.add(data_new);
-    }
-
-    fn list(self) -> Vec<String> {
-        self.raw_content
-    }
-
-    fn contains(&self, data: String) -> bool {
-        if self.enabled {
-            // for re in &self.captures {
-            //     if re.is_match(&data) {
-            //         return true;
-            //     }
-            // }
-
-            for item in &self.raw_content {
-                if &data == item {
-                    return true;
-                }
-            }
-        }
-
-        false
     }
 }

--- a/src/handlers/database.rs
+++ b/src/handlers/database.rs
@@ -5,12 +5,15 @@ use lazy_static::lazy_static;
 use rusqlite::{params, Connection as SqliteConnection};
 
 lazy_static! {
-    pub static ref TABLES: Vec<&'static str> = vec!["filters", "channels", "mentions"];
+    pub static ref TABLES: Vec<&'static str> = vec!["channels", "mentions"];
 }
 
 #[derive(Debug)]
 pub struct Database {
+    /// The connection to the sqlite database, held only for the constructor.
+    /// No public functions should be able to access this attribute.
     conn: SqliteConnection,
+    /// The tables pulled from the database, defined from the `TABLES` static string vector.
     tables: HashMap<String, DatabaseTable>,
 }
 
@@ -29,7 +32,7 @@ impl Database {
                 format!(
                     "CREATE TABLE IF NOT EXISTS {} (
                     id INTEGER PRIMARY KEY,
-                    content TEXT NOT NULL,
+                    content TEXT NOT NULL
                 )",
                     table
                 )

--- a/src/handlers/database.rs
+++ b/src/handlers/database.rs
@@ -1,0 +1,121 @@
+use regex::Regex;
+use rusqlite::Connection as SqliteConnection;
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct Database {
+    filters: DatabaseTable<Regex>,
+    channels: DatabaseTable<String>,
+    mentions: DatabaseTable<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct DatabaseTable<T> {
+    raw_content: Vec<String>,
+    converted_content: Vec<T>,
+    max_track: Option<u32>,
+    enabled: bool,
+}
+
+#[allow(dead_code)]
+impl Database {
+    pub fn new(conn: SqliteConnection) -> Self {
+        let get_table_data = |conn: &SqliteConnection, table: &str| -> Vec<String> {
+            conn.execute(
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {} (
+                    id INTEGER PRIMARY KEY,
+                    content TEXT NOT NULL,
+                )",
+                    table
+                )
+                .as_str(),
+                [],
+            )
+            .unwrap();
+
+            conn.prepare(format!("SELECT content FROM {}", table).as_str())
+                .unwrap()
+                .query_map([], |row| {
+                    let item: String = row.get(0).unwrap();
+
+                    Ok(item)
+                })
+                .unwrap()
+                .flatten()
+                .collect::<Vec<String>>()
+        };
+
+        let default_converter = |s: String| -> String { s };
+
+        Self {
+            filters: DatabaseTable::new(get_table_data(&conn, "filters"), |s: String| -> Regex {
+                Regex::new(&s).unwrap()
+            }),
+            channels: DatabaseTable::new(get_table_data(&conn, "channels"), default_converter),
+            mentions: DatabaseTable::new(get_table_data(&conn, "mentions"), default_converter),
+        }
+    }
+
+    pub fn dump(_conn: SqliteConnection) {
+        todo!()
+    }
+}
+
+#[allow(dead_code)]
+impl<T> DatabaseTable<T> {
+    pub fn new<F>(raw_content: Vec<String>, converter: F) -> Self
+    where
+        F: Fn(String) -> T,
+    {
+        let converted_content = raw_content
+            .iter()
+            .map(|f| converter(f.to_string()))
+            .collect::<Vec<T>>();
+
+        Self {
+            raw_content,
+            converted_content,
+            max_track: None,
+            enabled: true,
+        }
+    }
+
+    fn add(&mut self, data: &str) {
+        self.raw_content.push(data.to_string());
+    }
+
+    fn remove(&mut self, data: &str) {
+        if let Some(index) = self.raw_content.iter().position(|x| x.as_str() == data) {
+            self.raw_content.remove(index);
+        }
+    }
+
+    fn edit(&mut self, data_old: &str, data_new: &str) {
+        self.remove(data_old);
+        self.add(data_new);
+    }
+
+    fn list(self) -> Vec<String> {
+        self.raw_content
+    }
+
+    fn contains(&self, data: String) -> bool {
+        if self.enabled {
+            // for re in &self.captures {
+            //     if re.is_match(&data) {
+            //         return true;
+            //     }
+            // }
+
+            for item in &self.raw_content {
+                if &data == item {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}

--- a/src/handlers/filters.rs
+++ b/src/handlers/filters.rs
@@ -1,0 +1,98 @@
+use std::fs::read_to_string;
+
+use regex::Regex;
+
+use crate::handlers::config::FiltersConfig;
+
+#[derive(Debug, Clone)]
+pub struct Filters {
+    captures: Vec<Regex>,
+    enabled: bool,
+    reversed: bool,
+}
+
+impl Filters {
+    pub fn new(filter_path: String, config: FiltersConfig) -> Self {
+        Self {
+            captures: if let Ok(f) = read_to_string(filter_path) {
+                f.split('\n')
+                    .filter(|s| !s.is_empty())
+                    .flat_map(Regex::new)
+                    .collect::<Vec<Regex>>()
+            } else {
+                vec![]
+            },
+            enabled: config.enabled,
+            reversed: config.reversed,
+        }
+    }
+
+    pub fn contaminated(&self, data: String) -> bool {
+        if self.enabled {
+            for re in &self.captures {
+                if re.is_match(&data) {
+                    return !self.reversed;
+                }
+            }
+        }
+
+        self.reversed
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn toggle(&mut self) {
+        self.enabled = !self.enabled;
+    }
+
+    pub fn reverse(&mut self) {
+        self.reversed = !self.reversed;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Filters {
+        Filters {
+            captures: vec![Regex::new("^bad.*$").unwrap()],
+            enabled: true,
+            reversed: false,
+        }
+    }
+
+    #[test]
+    fn test_contaminated() {
+        let filters = setup();
+
+        assert!(filters.contaminated("bad word".to_string()));
+    }
+
+    #[test]
+    fn test_non_contaminated() {
+        let filters = setup();
+
+        assert!(!filters.contaminated("not a bad word".to_string()));
+    }
+
+    #[test]
+    fn test_reversed_contaminated() {
+        let mut filters = setup();
+
+        filters.reverse();
+
+        assert!(!filters.contaminated("bad word".to_string()));
+    }
+
+    #[test]
+    fn test_reversed_non_contaminated() {
+        let mut filters = setup();
+
+        filters.reverse();
+
+        assert!(filters.contaminated("not a bad word".to_string()));
+    }
+}

--- a/src/handlers/filters.rs
+++ b/src/handlers/filters.rs
@@ -47,6 +47,10 @@ impl Filters {
         self.enabled = !self.enabled;
     }
 
+    pub fn reversed(&self) -> bool {
+        self.reversed
+    }
+
     pub fn reverse(&mut self) {
         self.reversed = !self.reversed;
     }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -2,4 +2,5 @@ pub mod app;
 pub mod args;
 pub mod config;
 pub mod data;
+pub mod database;
 pub mod event;

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -4,3 +4,4 @@ pub mod config;
 pub mod data;
 pub mod database;
 pub mod event;
+pub mod filters;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -191,7 +191,7 @@ pub async fn ui_driver(
                                 let input_message =
                                     app.input_buffers.get_mut(&app.selected_buffer).unwrap();
 
-                                if !input_message.is_empty() {
+                                if !input_message.is_empty() && !app.filters.contaminated(input_message.to_string()) {
                                     app.messages.push_front(data_builder.user(
                                         config.twitch.username.to_string(),
                                         input_message.to_string(),

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -254,6 +254,12 @@ pub async fn ui_driver(
                         app.state = State::MessageSearch;
                         app.selected_buffer = BufferName::MessageHighlighter;
                     }
+                    Key::Ctrl('t') => {
+                        app.filters.toggle();
+                    }
+                    Key::Ctrl('r') => {
+                        app.filters.reverse();
+                    }
                     Key::Char('i') | Key::Insert => {
                         app.state = State::MessageInput;
                         app.selected_buffer = BufferName::Chat;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -216,6 +216,10 @@ pub async fn ui_driver(
                                         .unwrap();
 
                                     config.twitch.channel = input_message.to_string();
+
+                                    app.database
+                                        .add("channels".to_string(), input_message.to_string())
+                                        .unwrap();
                                 }
 
                                 input_message.update("", 0);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -202,6 +202,12 @@ pub async fn ui_driver(
                                     tx.send(Action::Privmsg(input_message.to_string()))
                                         .await
                                         .unwrap();
+
+                                    if let Some(msg) = input_message.strip_prefix('@') {
+                                        app.database
+                                            .add("mentions".to_string(), msg.to_string())
+                                            .unwrap();
+                                    }
                                 }
 
                                 input_message.update("", 0);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -191,7 +191,9 @@ pub async fn ui_driver(
                                 let input_message =
                                     app.input_buffers.get_mut(&app.selected_buffer).unwrap();
 
-                                if !input_message.is_empty() && !app.filters.contaminated(input_message.to_string()) {
+                                if !input_message.is_empty()
+                                    && !app.filters.contaminated(input_message.to_string())
+                                {
                                     app.messages.push_front(data_builder.user(
                                         config.twitch.username.to_string(),
                                         input_message.to_string(),

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -186,6 +186,16 @@ pub async fn ui_driver(
                         Key::Backspace | Key::Delete => {
                             input_buffer.backspace(1);
                         }
+                        Key::Tab => {
+                            let suggestion = app.buffer_suggestion.as_str();
+
+                            if !suggestion.is_empty() {
+                                app.input_buffers
+                                    .get_mut(&app.selected_buffer)
+                                    .unwrap()
+                                    .update(suggestion, suggestion.len());
+                            }
+                        }
                         Key::Enter => match app.selected_buffer {
                             BufferName::Chat => {
                                 let input_message =

--- a/src/twitch.rs
+++ b/src/twitch.rs
@@ -1,9 +1,10 @@
+use std::collections::HashMap;
+
 use futures::StreamExt;
 use irc::{
     client::{data, prelude::*, Client},
     proto::Command,
 };
-use std::collections::HashMap;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::handlers::{

--- a/src/ui/chunks/chatting.rs
+++ b/src/ui/chunks/chatting.rs
@@ -19,7 +19,7 @@ pub fn message_input<T: Backend>(frame: &mut Frame<T>, app: &mut App, verticals:
         let first_result = |choices: Vec<String>, choice: String| -> String {
             if let Some(result) = choices
                 .iter()
-                .filter(|f| f.starts_with(&choice[1..]))
+                .filter(|s| s.starts_with(&choice[1..]))
                 .collect::<Vec<&String>>()
                 .first()
             {
@@ -64,10 +64,14 @@ pub fn message_input<T: Backend>(frame: &mut Frame<T>, app: &mut App, verticals:
         input_rect.y + 1,
     );
 
-    let input_paragraph = Paragraph::new(Spans::from(vec![
+    let paragraph = Paragraph::new(Spans::from(vec![
         Span::raw(input_buffer.as_str()),
         Span::styled(
-            &suggestion[input_buffer.as_str().len()..],
+            if suggestion.len() > input_buffer.as_str().len() {
+                &suggestion[input_buffer.as_str().len()..]
+            } else {
+                ""
+            },
             Style::default().fg(Color::LightYellow),
         ),
     ]))
@@ -83,7 +87,9 @@ pub fn message_input<T: Backend>(frame: &mut Frame<T>, app: &mut App, verticals:
     ));
 
     frame.render_widget(
-        input_paragraph,
+        paragraph,
         verticals.chunks[verticals.constraints.len() - 1],
     );
+
+    app.buffer_suggestion = suggestion;
 }

--- a/src/ui/chunks/chatting.rs
+++ b/src/ui/chunks/chatting.rs
@@ -86,10 +86,7 @@ pub fn message_input<T: Backend>(frame: &mut Frame<T>, app: &mut App, verticals:
         ((cursor_pos + 3) as u16).saturating_sub(input_rect.width),
     ));
 
-    frame.render_widget(
-        paragraph,
-        verticals.chunks[verticals.constraints.len() - 1],
-    );
+    frame.render_widget(paragraph, verticals.chunks[verticals.constraints.len() - 1]);
 
     app.buffer_suggestion = suggestion;
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -41,19 +41,6 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
 
     let mut vertical_chunk_constraints = vec![Constraint::Min(1)];
 
-    // A little chunk to show you different commands when in insert mode
-    if let State::MessageInput = app.state {
-        if app
-            .input_buffers
-            .get(&app.selected_buffer)
-            .unwrap()
-            .as_str()
-            .starts_with('/')
-        {
-            vertical_chunk_constraints.push(Constraint::Length(9));
-        }
-    }
-
     // Allowing the input box to exist in different modes
     if let State::MessageInput | State::MessageSearch = app.state {
         vertical_chunk_constraints.extend(vec![Constraint::Length(3)]);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -91,7 +91,7 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
     let mut scroll_offset = app.scroll_offset;
 
     'outer: for data in app.messages.iter() {
-        if scroll_offset > 0 {
+        if scroll_offset > 0 && total_row_height > general_chunk_height {
             scroll_offset -= 1;
 
             continue;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -148,11 +148,20 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
                     vec!["Channel", config.twitch.channel.as_str()],
                     vec![
                         "Filters",
-                        if app.filters.enabled() {
-                            "enabled"
-                        } else {
-                            "disabled"
-                        },
+                        format!(
+                            "{} / {}",
+                            if app.filters.enabled() {
+                                "enabled"
+                            } else {
+                                "disabled"
+                            },
+                            if app.filters.reversed() {
+                                "reversed"
+                            } else {
+                                "static"
+                            }
+                        )
+                        .as_str(),
                     ],
                 ],
                 Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,7 +14,7 @@ use tui::{
 
 use crate::{
     handlers::{
-        app::{App, BufferName::MessageHighlighter, State},
+        app::{App, BufferName, State},
         config::CompleteConfig,
     },
     utils::styles,
@@ -104,7 +104,7 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
                 &config.frontend,
                 &message_chunk_width,
                 match app.selected_buffer {
-                    MessageHighlighter => Some(buffer.to_string()),
+                    BufferName::MessageHighlighter => Some(buffer.to_string()),
                     _ => None,
                 },
             )

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     handlers::{
         app::{App, BufferName, State},
         config::CompleteConfig,
+        data::PayLoad,
     },
     utils::styles,
 };
@@ -91,7 +92,13 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
     let mut scroll_offset = app.scroll_offset;
 
     'outer: for data in app.messages.iter() {
-        if scroll_offset > 0 && total_row_height > general_chunk_height {
+        if let PayLoad::Message(msg) = data.payload.clone() {
+            if app.filters.contaminated(msg) {
+                continue;
+            }
+        }
+
+        if scroll_offset > 0 {
             scroll_offset -= 1;
 
             continue;
@@ -147,6 +154,19 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
                     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                 ),
                 Span::raw(format!(": {} ]", config.twitch.channel)),
+                Span::raw(" [ "),
+                Span::styled(
+                    "Filters",
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(format!(
+                    ": {} ]",
+                    if app.filters.enabled() {
+                        "enabled"
+                    } else {
+                        "disabled"
+                    }
+                )),
             ])
         } else {
             Spans::default()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,7 +8,7 @@ use tui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     terminal::Frame,
-    text::{Span, Spans},
+    text::Spans,
     widgets::{Block, Borders, Cell, Row, Table},
 };
 
@@ -18,7 +18,7 @@ use crate::{
         config::CompleteConfig,
         data::PayLoad,
     },
-    utils::styles,
+    utils::{styles, text::title_spans},
 };
 
 #[derive(Debug, Clone)]
@@ -96,9 +96,7 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
             if app.filters.contaminated(msg) {
                 continue;
             }
-        }
-
-        if scroll_offset > 0 {
+        } else if scroll_offset > 0 {
             scroll_offset -= 1;
 
             continue;
@@ -139,35 +137,26 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
 
     let chat_title_format = || -> Spans {
         if config.frontend.title_shown {
-            Spans::from(vec![
-                Span::raw("[ "),
-                Span::styled(
-                    "Time",
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw(format!(
-                    ": {} ] [ ",
-                    Local::now().format(config.frontend.date_format.as_str())
-                )),
-                Span::styled(
-                    "Channel",
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw(format!(": {} ]", config.twitch.channel)),
-                Span::raw(" [ "),
-                Span::styled(
-                    "Filters",
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw(format!(
-                    ": {} ]",
-                    if app.filters.enabled() {
-                        "enabled"
-                    } else {
-                        "disabled"
-                    }
-                )),
-            ])
+            title_spans(
+                vec![
+                    vec![
+                        "Time",
+                        &Local::now()
+                            .format(config.frontend.date_format.as_str())
+                            .to_string(),
+                    ],
+                    vec!["Channel", config.twitch.channel.as_str()],
+                    vec![
+                        "Filters",
+                        if app.filters.enabled() {
+                            "enabled"
+                        } else {
+                            "disabled"
+                        },
+                    ],
+                ],
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            )
         } else {
             Spans::default()
         }

--- a/src/utils/pathing.rs
+++ b/src/utils/pathing.rs
@@ -1,46 +1,59 @@
-use std::panic::panic_any;
-
 const BINARY_NAME: &str = env!("CARGO_BIN_NAME");
 
-pub fn config_path() -> String {
+pub fn config_path(file: &str) -> String {
     match std::env::consts::OS {
-        "linux" | "macos" => match std::env::var("HOME") {
-            Ok(env_home_path) => format!("{}/.config/{}/config.toml", env_home_path, BINARY_NAME),
-            Err(err) => panic_any(err),
-        },
-        "windows" => match std::env::var("APPDATA") {
-            Ok(appdata_path) => format!("{}\\{}\\config.toml", appdata_path, BINARY_NAME),
-            Err(err) => std::panic::panic_any(err),
-        },
+        "linux" | "macos" => format!(
+            "{}/.config/{}/{}",
+            std::env::var("HOME").unwrap(),
+            BINARY_NAME,
+            file
+        ),
+        "windows" => format!(
+            "{}\\{}\\{}",
+            std::env::var("APPDATA").unwrap(),
+            BINARY_NAME,
+            file
+        ),
         _ => unimplemented!(),
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[test]
+#[cfg(target_os = "windows")]
+fn test_windows_config_path() {
+    assert_eq!(
+        config_path("config.toml"),
+        format!(
+            "{}\\{}\\config.toml",
+            std::env::var("APPDATA").unwrap(),
+            BINARY_NAME
+        )
+    )
+}
 
-    #[test]
-    #[cfg(target_os = "windows")]
-    fn test_windows_config_path() {
-        match std::env::var("APPDATA") {
-            Ok(appdata_path) => assert_eq!(
-                config_path(),
-                format!("{}\\{}\\config.toml", appdata_path, BINARY_NAME)
-            ),
-            Err(err) => std::panic::panic_any(err),
-        }
-    }
+#[test]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn test_unix_config_path() {
+    assert_eq!(
+        config_path("config.toml"),
+        format!(
+            "{}/.config/{}/config.toml",
+            std::env::var("HOME").unwrap(),
+            BINARY_NAME,
+        )
+    )
+}
 
-    #[test]
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    fn test_unix_config_path() {
-        match std::env::var("HOME") {
-            Ok(env_home_path) => assert_eq!(
-                config_path(),
-                format!("{}/.config/{}/config.toml", env_home_path, BINARY_NAME)
-            ),
-            Err(err) => std::panic::panic_any(err),
-        }
-    }
+#[test]
+#[should_panic]
+#[cfg(any(
+    target_os = "ios",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "openbsd",
+    target_os = "netbsd"
+))]
+fn test_ios_config_path() {
+    config_path("config.toml");
 }

--- a/src/utils/pathing.rs
+++ b/src/utils/pathing.rs
@@ -18,42 +18,47 @@ pub fn config_path(file: &str) -> String {
     }
 }
 
-#[test]
-#[cfg(target_os = "windows")]
-fn test_windows_config_path() {
-    assert_eq!(
-        config_path("config.toml"),
-        format!(
-            "{}\\{}\\config.toml",
-            std::env::var("APPDATA").unwrap(),
-            BINARY_NAME
-        )
-    )
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-fn test_unix_config_path() {
-    assert_eq!(
-        config_path("config.toml"),
-        format!(
-            "{}/.config/{}/config.toml",
-            std::env::var("HOME").unwrap(),
-            BINARY_NAME,
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_windows_config_path() {
+        assert_eq!(
+            config_path("config.toml"),
+            format!(
+                "{}\\{}\\config.toml",
+                std::env::var("APPDATA").unwrap(),
+                BINARY_NAME
+            )
         )
-    )
-}
+    }
 
-#[test]
-#[should_panic]
-#[cfg(any(
-    target_os = "ios",
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "openbsd",
-    target_os = "netbsd"
-))]
-fn test_ios_config_path() {
-    config_path("config.toml");
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn test_unix_config_path() {
+        assert_eq!(
+            config_path("config.toml"),
+            format!(
+                "{}/.config/{}/config.toml",
+                std::env::var("HOME").unwrap(),
+                BINARY_NAME,
+            )
+        )
+    }
+
+    #[test]
+    #[should_panic]
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))]
+    fn test_ios_config_path() {
+        config_path("config.toml");
+    }
 }

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -79,101 +79,105 @@ pub fn get_cursor_position(line_buffer: &LineBuffer) -> usize {
         .sum()
 }
 
-#[test]
-#[should_panic(expected = "Parameter of 'maximum_length' cannot be below 1.")]
-fn test_text_align_maximum_length() {
-    align_text("", "left", 0);
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    #[should_panic(expected = "Parameter of 'maximum_length' cannot be below 1.")]
+    fn test_text_align_maximum_length() {
+        align_text("", "left", 0);
+    }
 
-#[test]
-fn test_text_align_left() {
-    assert_eq!(align_text("a", "left", 10), "a".to_string());
-    assert_eq!(align_text("a", "left", 1), "a".to_string());
-}
+    #[test]
+    fn test_text_align_left() {
+        assert_eq!(align_text("a", "left", 10), "a".to_string());
+        assert_eq!(align_text("a", "left", 1), "a".to_string());
+    }
 
-#[test]
-fn test_text_align_right() {
-    assert_eq!(
-        align_text("a", "right", 10),
-        format!("{}{}", " ".repeat(9), "a")
-    );
-    assert_eq!(align_text("a", "right", 1), "a".to_string());
-    assert_eq!(align_text("你好", "right", 5), " 你好");
-    assert_eq!(align_text("👑123", "right", 6), " 👑123");
-}
+    #[test]
+    fn test_text_align_right() {
+        assert_eq!(
+            align_text("a", "right", 10),
+            format!("{}{}", " ".repeat(9), "a")
+        );
+        assert_eq!(align_text("a", "right", 1), "a".to_string());
+        assert_eq!(align_text("你好", "right", 5), " 你好");
+        assert_eq!(align_text("👑123", "right", 6), " 👑123");
+    }
 
-#[test]
-fn test_text_align_center() {
-    assert_eq!(
-        align_text("a", "center", 11),
-        format!("{}{}{}", " ".repeat(5), "a", " ".repeat(5))
-    );
-    assert_eq!(align_text("a", "center", 1), "a".to_string());
-    assert_eq!(align_text("你好", "center", 6), " 你好 ");
-    assert_eq!(align_text("👑123", "center", 7), " 👑123 ");
-}
+    #[test]
+    fn test_text_align_center() {
+        assert_eq!(
+            align_text("a", "center", 11),
+            format!("{}{}{}", " ".repeat(5), "a", " ".repeat(5))
+        );
+        assert_eq!(align_text("a", "center", 1), "a".to_string());
+        assert_eq!(align_text("你好", "center", 6), " 你好 ");
+        assert_eq!(align_text("👑123", "center", 7), " 👑123 ");
+    }
 
-#[test]
-#[should_panic(expected = "Vector length should be greater than or equal to 1.")]
-fn test_vector_column_max_empty_vector() {
-    let vec: Vec<Vec<String>> = vec![];
+    #[test]
+    #[should_panic(expected = "Vector length should be greater than or equal to 1.")]
+    fn test_vector_column_max_empty_vector() {
+        let vec: Vec<Vec<String>> = vec![];
 
-    vector_column_max(&vec, None);
-}
+        vector_column_max(&vec, None);
+    }
 
-#[test]
-fn test_vector_column_max_reference_strings() {
-    let vec = vec![vec!["", "s"], vec!["longer string", "lll"]];
+    #[test]
+    fn test_vector_column_max_reference_strings() {
+        let vec = vec![vec!["", "s"], vec!["longer string", "lll"]];
 
-    let mut output_vec_all = vector_column_max(&vec, None);
+        let mut output_vec_all = vector_column_max(&vec, None);
 
-    assert_eq!(output_vec_all.next(), Some(13));
-    assert_eq!(output_vec_all.next(), Some(3));
+        assert_eq!(output_vec_all.next(), Some(13));
+        assert_eq!(output_vec_all.next(), Some(3));
 
-    let mut output_vec_one = vector_column_max(&vec, Some(0));
+        let mut output_vec_one = vector_column_max(&vec, Some(0));
 
-    assert_eq!(output_vec_one.next(), Some(13));
-}
+        assert_eq!(output_vec_one.next(), Some(13));
+    }
 
-#[test]
-fn test_vector_column_max_strings() {
-    let vec = vec![
-        vec!["".to_string(), "another".to_string()],
-        vec!["".to_string(), "the last string".to_string()],
-    ];
+    #[test]
+    fn test_vector_column_max_strings() {
+        let vec = vec![
+            vec!["".to_string(), "another".to_string()],
+            vec!["".to_string(), "the last string".to_string()],
+        ];
 
-    let mut output_vec_all = vector_column_max(&vec, None);
+        let mut output_vec_all = vector_column_max(&vec, None);
 
-    assert_eq!(output_vec_all.next(), Some(0));
-    assert_eq!(output_vec_all.next(), Some(15));
+        assert_eq!(output_vec_all.next(), Some(0));
+        assert_eq!(output_vec_all.next(), Some(15));
 
-    let mut output_vec_one = vector_column_max(&vec, Some(0));
+        let mut output_vec_one = vector_column_max(&vec, Some(0));
 
-    assert_eq!(output_vec_one.next(), Some(0));
-}
+        assert_eq!(output_vec_one.next(), Some(0));
+    }
 
-#[test]
-fn test_get_cursor_position_with_single_byte_graphemes() {
-    let text = "never gonna give you up";
-    let mut line_buffer = LineBuffer::with_capacity(25);
-    line_buffer.insert_str(0, text);
+    #[test]
+    fn test_get_cursor_position_with_single_byte_graphemes() {
+        let text = "never gonna give you up";
+        let mut line_buffer = LineBuffer::with_capacity(25);
+        line_buffer.insert_str(0, text);
 
-    assert_eq!(get_cursor_position(&line_buffer), 0);
-    line_buffer.move_forward(1);
-    assert_eq!(get_cursor_position(&line_buffer), 1);
-    line_buffer.move_forward(2);
-    assert_eq!(get_cursor_position(&line_buffer), 3);
-}
+        assert_eq!(get_cursor_position(&line_buffer), 0);
+        line_buffer.move_forward(1);
+        assert_eq!(get_cursor_position(&line_buffer), 1);
+        line_buffer.move_forward(2);
+        assert_eq!(get_cursor_position(&line_buffer), 3);
+    }
 
-#[test]
-fn test_get_cursor_position_with_three_byte_graphemes() {
-    let text = "绝对不会放弃你";
-    let mut line_buffer = LineBuffer::with_capacity(25);
-    line_buffer.insert_str(0, text);
+    #[test]
+    fn test_get_cursor_position_with_three_byte_graphemes() {
+        let text = "绝对不会放弃你";
+        let mut line_buffer = LineBuffer::with_capacity(25);
+        line_buffer.insert_str(0, text);
 
-    assert_eq!(get_cursor_position(&line_buffer), 0);
-    line_buffer.move_forward(1);
-    assert_eq!(get_cursor_position(&line_buffer), 2);
-    line_buffer.move_forward(2);
-    assert_eq!(get_cursor_position(&line_buffer), 6);
+        assert_eq!(get_cursor_position(&line_buffer), 0);
+        line_buffer.move_forward(1);
+        assert_eq!(get_cursor_position(&line_buffer), 2);
+        line_buffer.move_forward(2);
+        assert_eq!(get_cursor_position(&line_buffer), 6);
+    }
 }

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -79,106 +79,101 @@ pub fn get_cursor_position(line_buffer: &LineBuffer) -> usize {
         .sum()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[test]
+#[should_panic(expected = "Parameter of 'maximum_length' cannot be below 1.")]
+fn test_text_align_maximum_length() {
+    align_text("", "left", 0);
+}
 
-    #[test]
-    #[should_panic(expected = "Parameter of 'maximum_length' cannot be below 1.")]
-    fn test_text_align_maximum_length() {
-        align_text("", "left", 0);
-    }
+#[test]
+fn test_text_align_left() {
+    assert_eq!(align_text("a", "left", 10), "a".to_string());
+    assert_eq!(align_text("a", "left", 1), "a".to_string());
+}
 
-    #[test]
-    fn test_text_align_left() {
-        assert_eq!(align_text("a", "left", 10), "a".to_string());
-        assert_eq!(align_text("a", "left", 1), "a".to_string());
-    }
+#[test]
+fn test_text_align_right() {
+    assert_eq!(
+        align_text("a", "right", 10),
+        format!("{}{}", " ".repeat(9), "a")
+    );
+    assert_eq!(align_text("a", "right", 1), "a".to_string());
+    assert_eq!(align_text("你好", "right", 5), " 你好");
+    assert_eq!(align_text("👑123", "right", 6), " 👑123");
+}
 
-    #[test]
-    fn test_text_align_right() {
-        assert_eq!(
-            align_text("a", "right", 10),
-            format!("{}{}", " ".repeat(9), "a")
-        );
-        assert_eq!(align_text("a", "right", 1), "a".to_string());
-        assert_eq!(align_text("你好", "right", 5), " 你好");
-        assert_eq!(align_text("👑123", "right", 6), " 👑123");
-    }
+#[test]
+fn test_text_align_center() {
+    assert_eq!(
+        align_text("a", "center", 11),
+        format!("{}{}{}", " ".repeat(5), "a", " ".repeat(5))
+    );
+    assert_eq!(align_text("a", "center", 1), "a".to_string());
+    assert_eq!(align_text("你好", "center", 6), " 你好 ");
+    assert_eq!(align_text("👑123", "center", 7), " 👑123 ");
+}
 
-    #[test]
-    fn test_text_align_center() {
-        assert_eq!(
-            align_text("a", "center", 11),
-            format!("{}{}{}", " ".repeat(5), "a", " ".repeat(5))
-        );
-        assert_eq!(align_text("a", "center", 1), "a".to_string());
-        assert_eq!(align_text("你好", "center", 6), " 你好 ");
-        assert_eq!(align_text("👑123", "center", 7), " 👑123 ");
-    }
+#[test]
+#[should_panic(expected = "Vector length should be greater than or equal to 1.")]
+fn test_vector_column_max_empty_vector() {
+    let vec: Vec<Vec<String>> = vec![];
 
-    #[test]
-    #[should_panic(expected = "Vector length should be greater than or equal to 1.")]
-    fn test_vector_column_max_empty_vector() {
-        let vec: Vec<Vec<String>> = vec![];
+    vector_column_max(&vec, None);
+}
 
-        vector_column_max(&vec, None);
-    }
+#[test]
+fn test_vector_column_max_reference_strings() {
+    let vec = vec![vec!["", "s"], vec!["longer string", "lll"]];
 
-    #[test]
-    fn test_vector_column_max_reference_strings() {
-        let vec = vec![vec!["", "s"], vec!["longer string", "lll"]];
+    let mut output_vec_all = vector_column_max(&vec, None);
 
-        let mut output_vec_all = vector_column_max(&vec, None);
+    assert_eq!(output_vec_all.next(), Some(13));
+    assert_eq!(output_vec_all.next(), Some(3));
 
-        assert_eq!(output_vec_all.next(), Some(13));
-        assert_eq!(output_vec_all.next(), Some(3));
+    let mut output_vec_one = vector_column_max(&vec, Some(0));
 
-        let mut output_vec_one = vector_column_max(&vec, Some(0));
+    assert_eq!(output_vec_one.next(), Some(13));
+}
 
-        assert_eq!(output_vec_one.next(), Some(13));
-    }
+#[test]
+fn test_vector_column_max_strings() {
+    let vec = vec![
+        vec!["".to_string(), "another".to_string()],
+        vec!["".to_string(), "the last string".to_string()],
+    ];
 
-    #[test]
-    fn test_vector_column_max_strings() {
-        let vec = vec![
-            vec!["".to_string(), "another".to_string()],
-            vec!["".to_string(), "the last string".to_string()],
-        ];
+    let mut output_vec_all = vector_column_max(&vec, None);
 
-        let mut output_vec_all = vector_column_max(&vec, None);
+    assert_eq!(output_vec_all.next(), Some(0));
+    assert_eq!(output_vec_all.next(), Some(15));
 
-        assert_eq!(output_vec_all.next(), Some(0));
-        assert_eq!(output_vec_all.next(), Some(15));
+    let mut output_vec_one = vector_column_max(&vec, Some(0));
 
-        let mut output_vec_one = vector_column_max(&vec, Some(0));
+    assert_eq!(output_vec_one.next(), Some(0));
+}
 
-        assert_eq!(output_vec_one.next(), Some(0));
-    }
+#[test]
+fn test_get_cursor_position_with_single_byte_graphemes() {
+    let text = "never gonna give you up";
+    let mut line_buffer = LineBuffer::with_capacity(25);
+    line_buffer.insert_str(0, text);
 
-    #[test]
-    fn test_get_cursor_position_with_single_byte_graphemes() {
-        let text = "never gonna give you up";
-        let mut line_buffer = LineBuffer::with_capacity(25);
-        line_buffer.insert_str(0, text);
+    assert_eq!(get_cursor_position(&line_buffer), 0);
+    line_buffer.move_forward(1);
+    assert_eq!(get_cursor_position(&line_buffer), 1);
+    line_buffer.move_forward(2);
+    assert_eq!(get_cursor_position(&line_buffer), 3);
+}
 
-        assert_eq!(get_cursor_position(&line_buffer), 0);
-        line_buffer.move_forward(1);
-        assert_eq!(get_cursor_position(&line_buffer), 1);
-        line_buffer.move_forward(2);
-        assert_eq!(get_cursor_position(&line_buffer), 3);
-    }
+#[test]
+fn test_get_cursor_position_with_three_byte_graphemes() {
+    let text = "绝对不会放弃你";
+    let mut line_buffer = LineBuffer::with_capacity(25);
+    line_buffer.insert_str(0, text);
 
-    #[test]
-    fn test_get_cursor_position_with_three_byte_graphemes() {
-        let text = "绝对不会放弃你";
-        let mut line_buffer = LineBuffer::with_capacity(25);
-        line_buffer.insert_str(0, text);
-
-        assert_eq!(get_cursor_position(&line_buffer), 0);
-        line_buffer.move_forward(1);
-        assert_eq!(get_cursor_position(&line_buffer), 2);
-        line_buffer.move_forward(2);
-        assert_eq!(get_cursor_position(&line_buffer), 6);
-    }
+    assert_eq!(get_cursor_position(&line_buffer), 0);
+    line_buffer.move_forward(1);
+    assert_eq!(get_cursor_position(&line_buffer), 2);
+    line_buffer.move_forward(2);
+    assert_eq!(get_cursor_position(&line_buffer), 6);
 }

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,6 +1,5 @@
-use std::vec::IntoIter;
-
 use rustyline::line_buffer::LineBuffer;
+use std::vec::IntoIter;
 use textwrap::core::display_width;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;


### PR DESCRIPTION
Closes #71

Using a text file at `config_path("filters.txt")`, messages will be filtered out based on the regex inputs.

Originally username filtering was going to be implemented, but then I realized that Twitch does that themselves upon account creation.

Also, a user will be able to query recent mentions of other users, and previously switched to/from channels by `tab` key completion.

`@` will activate suggestions for mentions if at the start of a message, `/` will suggest commands from the static vector of them in the respective [`statics.rs`](https://github.com/Xithrius/twitch-tui/blob/main/src/ui/statics.rs#L27-L61) file. 