### PR TITLE
disable filters in default config

### DIFF
--- a/default-config.toml
+++ b/default-config.toml
@@ -22,9 +22,9 @@ mentions = true
 
 [filters]
 # If filters should be enabled at all.
-enabled = true
+enabled = false
 # If the regex filters should be reversed.
-reversed = true
+reversed = false
 
 [frontend]
 # If the time and date is to be shown.


### PR DESCRIPTION
No messages appear when using the default config, disabling the filters by default should fix this.