### PR TITLE
feat: add interactive config on first start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +302,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
+dependencies = [
+ "console",
+ "shell-words",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +331,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding"
@@ -1247,6 +1276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1579,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "crossterm",
+ "dialoguer",
  "fern",
  "futures",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ regex = "1.7.0"
 color-eyre = "0.6.2"
 log = "0.4.17"
 fern = "0.6.1"
+dialoguer = { version = "0.10.3", default-features = false }
 
 [[bin]]
 bench = false

--- a/src/handlers/interactive.rs
+++ b/src/handlers/interactive.rs
@@ -1,0 +1,51 @@
+use crate::handlers::config::{CompleteConfig, TwitchConfig};
+use dialoguer::console::Style;
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::{Confirm, Input};
+
+pub(super) fn interactive_config() -> Option<CompleteConfig> {
+    let theme = ColorfulTheme {
+        values_style: Style::new().yellow().dim(),
+        ..ColorfulTheme::default()
+    };
+    println!("It looks like Twitch TUI is not configured yet.");
+
+    if !Confirm::with_theme(&theme)
+        .with_prompt("Do you want to use interactive wizard?")
+        .interact()
+        .ok()?
+    {
+        return None;
+    }
+
+    let username: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Username: ")
+        .interact_text()
+        .unwrap();
+
+    let token: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Token: ")
+        .interact_text()
+        .unwrap();
+
+    let channel: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Channel: ")
+        .interact_text()
+        .unwrap();
+
+    let server: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("IRC server: ")
+        .default("irc.chat.twitch.tv".to_string())
+        .interact_text()
+        .unwrap();
+
+    Some(CompleteConfig {
+        twitch: TwitchConfig {
+            username,
+            channel,
+            server,
+            token: Some(token),
+        },
+        ..Default::default()
+    })
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,5 +3,6 @@ pub mod args;
 pub mod config;
 pub mod data;
 pub mod filters;
+mod interactive;
 pub mod storage;
 pub mod user_input;


### PR DESCRIPTION
Hi,

I've seen your request for contribution in rust discord.

I wanted to try it out and see how I can contribute.

And immediately, on first start, it just bailed out and told me to update the config file. That is fine, however i feel like an interactive configuration would be nice.

Here is a proposal to add interactive wizard in case config file does not exist yet. 

It only asks for the twitch config atm but it other options can be added.

it also asks if you wish to do the interactive wizard and if not, it reverts to original way of creating default config and bailing out. 