### PR TITLE
Minor refactoring.

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -125,8 +125,8 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
             continue;
         }
 
-        let username_highlight = if config.frontend.username_highlight {
-            Some(config.twitch.username.clone())
+        let username_highlight: Option<&str> = if config.frontend.username_highlight {
+            Some(&config.twitch.username)
         } else {
             None
         };
@@ -138,11 +138,11 @@ pub fn draw_ui<T: Backend>(frame: &mut Frame<T>, app: &mut App, config: &Complet
                 None
             } else {
                 match &app.get_state() {
-                    State::MessageSearch => Some(app.input_buffer.to_string()),
+                    State::MessageSearch => Some(app.input_buffer.as_str()),
                     _ => None,
                 }
             },
-            &username_highlight,
+            username_highlight,
         );
 
         for span in spans.iter().rev() {

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use rustyline::line_buffer::LineBuffer;
 use tui::{style::Style, text::Span};
 use unicode_segmentation::UnicodeSegmentation;
@@ -11,6 +13,21 @@ pub fn get_cursor_position(line_buffer: &LineBuffer) -> usize {
         .take_while(|(offset, _)| *offset != line_buffer.pos())
         .map(|(_, cluster)| cluster.width())
         .sum()
+}
+
+pub fn split_cow_in_place<'a>(cow: &mut Cow<'a, str>, mid: usize) -> Cow<'a, str> {
+    match *cow {
+        Cow::Owned(ref mut s) => {
+            let s2 = s[mid..].to_string();
+            s.truncate(mid);
+            Cow::Owned(s2)
+        }
+        Cow::Borrowed(s) => {
+            let (s1, s2) = s.split_at(mid);
+            *cow = Cow::Borrowed(s1);
+            Cow::Borrowed(s2)
+        }
+    }
 }
 
 pub enum TitleStyle<'a> {


### PR DESCRIPTION
Haven't looked at other parts of the codebase, might be able to simplify some stuff further.

Note that the `to_spans` refactor also fixes the following:
- `highlight_name` and `search` colors will both show up instead of only `search` previously
- all name occurrences in `highlight_name` will be highlighted, not just the first

```
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣤⣤⣤⣤⣤⣶⣦⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⡿⠛⠉⠙⠛⠛⠛⠛⠻⢿⣿⣷⣤⡀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⣼⣿⠋⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⠈⢻⣿⣿⡄⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⣸⣿⡏⠀⠀⠀⣠⣶⣾⣿⣿⣿⠿⠿⠿⢿⣿⣿⣿⣄⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⣿⣿⠁⠀⠀⢰⣿⣿⣯⠁⠀⠀⠀⠀⠀⠀⠀⠈⠙⢿⣷⡄⠀
⠀⠀⣀⣤⣴⣶⣶⣿⡟⠀⠀⠀⢸⣿⣿⣿⣆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣷⠀
⠀⢰⣿⡟⠋⠉⣹⣿⡇⠀⠀⠀⠘⣿⣿⣿⣿⣷⣦⣤⣤⣤⣶⣶⣶⣶⣿⣿⣿⠀
⠀⢸⣿⡇⠀⠀⣿⣿⡇⠀⠀⠀⠀⠹⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠃⠀
⠀⣸⣿⡇⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠉⠻⠿⣿⣿⣿⣿⡿⠿⠿⠛⢻⣿⡇⠀⠀
⠀⠸⣿⣧⡀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣿⠃⠀⠀
⠀⠀⠛⢿⣿⣿⣿⣿⣇⠀⠀⠀⠀⠀⣰⣿⣿⣷⣶⣶⣶⣶⠶⠀⢠⣿⣿⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⣿⣿⠀⠀⠀⠀⠀⣿⣿⡇⠀⣽⣿⡏⠁⠀⠀⢸⣿⡇⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⣿⣿⠀⠀⠀⠀⠀⣿⣿⡇⠀⢹⣿⡆⠀⠀⠀⣸⣿⠇⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⢿⣿⣦⣄⣀⣠⣴⣿⣿⠁⠀⠈⠻⣿⣿⣿⣿⡿⠏⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠈⠛⠻⠿⠿⠿⠿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
```