### PR TITLE
Add support for webp emotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,8 +1010,7 @@ dependencies = [
 [[package]]
 name = "image"
 version = "0.24.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
+source = "git+https://github.com/Nogesma/image#4bd97d5561439da5dc724b7d0dc2e0f9a3e4cecb"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1140,12 +1139,6 @@ checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "lazy_static"
@@ -2213,7 +2206,6 @@ dependencies = [
  "fuzzy-matcher",
  "image",
  "irc",
- "json",
  "lazy_static",
  "log",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,8 @@ color-eyre = "0.6.2"
 log = "0.4.17"
 fern = "0.6.2"
 dialoguer = { version = "0.10.3", default-features = false }
-reqwest = "0.11.14"
-json = "0.12.4"
-image = "0.24.5"
+reqwest = { version = "0.11.14", features = ["json"]}
+image = { git = "https://github.com/Nogesma/image" }
 base64 = "0.21.0"
 tempfile = "3.4.0"
 anyhow = "1.0.70"

--- a/src/emotes/downloader.rs
+++ b/src/emotes/downloader.rs
@@ -1,36 +1,77 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use futures::StreamExt;
 use log::warn;
 use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION},
     Client,
 };
+use serde::Deserialize;
 use std::{borrow::BorrowMut, collections::HashMap, path::Path};
 use tokio::io::AsyncWriteExt;
 
 use crate::{handlers::config::CompleteConfig, utils::pathing::cache_path};
 
-// HashMap of emote name, emote filename, emote url
-type EmoteMap = HashMap<String, (String, String)>;
+// HashMap of emote name, emote filename, emote url, and if the emote is an overlay
+type EmoteMap = HashMap<String, (String, String, bool)>;
+
+#[derive(Deserialize)]
+struct StringAttribute {
+    #[serde(rename = "id", alias = "client_id", alias = "url_1x")]
+    value: String,
+}
+
+#[derive(Deserialize)]
+struct VecAttribute<T> {
+    #[serde(rename = "data", alias = "emotes")]
+    value: Vec<T>,
+}
+
+#[derive(Deserialize)]
+struct TwitchEmote {
+    id: String,
+    name: String,
+    images: StringAttribute,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BetterTTVEmote {
+    id: String,
+    code: String,
+    image_type: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BetterTTVEmotes {
+    channel_emotes: Vec<BetterTTVEmote>,
+    shared_emotes: Vec<BetterTTVEmote>,
+}
+
+#[derive(Deserialize)]
+struct SevenTVEmoteSet {
+    emote_set: StringAttribute,
+}
+
+#[derive(Deserialize)]
+struct SevenTVEmote {
+    name: String,
+    id: String,
+    flags: u64,
+}
 
 async fn get_twitch_client_id(token: &str) -> Result<String> {
     let client = Client::new();
 
-    let res = client
+    Ok(client
         .get("https://id.twitch.tv/oauth2/validate")
         .header(AUTHORIZATION, &format!("OAuth {token}"))
         .send()
         .await?
-        .error_for_status()?;
-
-    let json = json::parse(&res.text().await?)?;
-    let client_id = &json["client_id"];
-
-    if let json::JsonValue::String(id) = client_id {
-        Ok(id.clone())
-    } else {
-        Err(anyhow!("Unable to parse client id from twitch response."))
-    }
+        .error_for_status()?
+        .json::<StringAttribute>()
+        .await?
+        .value)
 }
 
 async fn get_twitch_client(config: &CompleteConfig) -> Result<Client> {
@@ -55,185 +96,181 @@ async fn get_twitch_client(config: &CompleteConfig) -> Result<Client> {
 }
 
 async fn get_channel_id(client: &Client, channel: &str) -> Result<i32> {
-    let res = client
+    Ok(client
         .get(format!("https://api.twitch.tv/helix/users?login={channel}",))
         .send()
         .await?
-        .error_for_status()?;
-
-    let json = json::parse(res.text().await?.as_str())?;
-    Ok(json["data"][0]["id"].to_string().parse()?)
+        .error_for_status()?
+        .json::<VecAttribute<StringAttribute>>()
+        .await?
+        .value
+        .first()
+        .context("Could not get channel id.")?
+        .value
+        .parse()?)
 }
 
 async fn get_twitch_emotes(client: &Client, channel_id: i32) -> Result<EmoteMap> {
-    let res = client
+    let channel_emotes = client
         .get(format!(
             "https://api.twitch.tv/helix/chat/emotes?broadcaster_id={channel_id}",
         ))
         .send()
         .await?
-        .error_for_status()?;
+        .error_for_status()?
+        .json::<VecAttribute<TwitchEmote>>()
+        .await?
+        .value;
 
-    let json = json::parse(&res.text().await?)?;
-    let channel_emotes = &json["data"];
-
-    let res = client
+    let global_emotes = client
         .get("https://api.twitch.tv/helix/chat/emotes/global")
         .send()
         .await?
-        .error_for_status()?;
+        .error_for_status()?
+        .json::<VecAttribute<TwitchEmote>>()
+        .await?
+        .value;
 
-    let json = json::parse(&res.text().await?)?;
-    let global_emotes = &json["data"];
-
-    let mut emotes_map = HashMap::new();
-
-    for twitch_emote in [channel_emotes, global_emotes] {
-        if let json::JsonValue::Array(emotes) = twitch_emote {
-            emotes_map.extend(emotes.iter().map(|emote| {
-                let id = emote["id"].to_string();
-                let url =
-                    format!("https://static-cdn.jtvnw.net/emoticons/v2/{id}/static/light/1.0");
-
-                (emote["name"].to_string(), (id, url))
-            }));
-        }
-    }
-
-    Ok(emotes_map)
+    Ok(channel_emotes
+        .into_iter()
+        .chain(global_emotes)
+        .map(|emote| (emote.name, (emote.id, emote.images.value, false)))
+        .collect())
 }
 
 async fn get_betterttv_emotes(channel_id: i32) -> Result<EmoteMap> {
     let client = Client::new();
 
-    let res = client
+    let BetterTTVEmotes {
+        channel_emotes,
+        shared_emotes,
+    } = client
         .get(format!(
             "https://api.betterttv.net/3/cached/users/twitch/{channel_id}",
         ))
         .send()
         .await?
-        .error_for_status()?;
+        .error_for_status()?
+        .json::<BetterTTVEmotes>()
+        .await?;
 
-    let json = json::parse(&res.text().await?)?;
-
-    let channel_emotes = &json["channelEmotes"];
-    let shared_emotes = &json["sharedEmotes"];
-
-    let res = client
+    let global_emotes: Vec<BetterTTVEmote> = client
         .get("https://api.betterttv.net/3/cached/emotes/global")
         .send()
         .await?
-        .error_for_status()?;
+        .error_for_status()?
+        .json()
+        .await?;
 
-    let global_emotes = &json::parse(&res.text().await?)?;
-
-    let mut emotes_map = HashMap::new();
-
-    for bttv_emote in [channel_emotes, shared_emotes, global_emotes] {
-        if let json::JsonValue::Array(emotes) = bttv_emote {
-            emotes_map.extend(emotes.iter().map(|emote| {
-                let id = emote["id"].to_string();
-                let image_type = emote["imageType"].to_string();
-
+    Ok(channel_emotes
+        .into_iter()
+        .chain(shared_emotes)
+        .chain(global_emotes)
+        .map(
+            |BetterTTVEmote {
+                 code,
+                 id,
+                 image_type,
+             }| {
                 (
-                    emote["code"].to_string(),
+                    code,
                     (
                         format!("{id}.{image_type}"),
                         format!("https://cdn.betterttv.net/emote/{id}/1x.{image_type}"),
+                        false,
                     ),
                 )
-            }));
-        }
-    }
-
-    Ok(emotes_map)
+            },
+        )
+        .collect())
 }
 
 async fn get_7tv_emotes(channel_id: i32) -> Result<EmoteMap> {
     let client = Client::new();
 
-    let res = client
+    let set = client
         .get(format!("https://7tv.io/v3/users/twitch/{channel_id}",))
         .send()
         .await?
-        .error_for_status()?;
+        .error_for_status()?
+        .json::<SevenTVEmoteSet>()
+        .await?
+        .emote_set
+        .value;
 
-    let json = json::parse(&res.text().await?)?;
-    let set = &json["emote_set"]["id"];
-
-    let res = client
+    let channel_emotes = client
         .get(format!("https://7tv.io/v3/emote-sets/{set}",))
         .send()
         .await?
-        .error_for_status()?;
+        .error_for_status()?
+        .json::<VecAttribute<SevenTVEmote>>()
+        .await?
+        .value;
 
-    let json = json::parse(&res.text().await?)?;
-    let channel_emotes = &json["emotes"];
-
-    let res = client
+    let global_emotes = client
         .get("https://7tv.io/v3/emote-sets/global")
         .send()
         .await?
-        .error_for_status()?;
+        .error_for_status()?
+        .json::<VecAttribute<SevenTVEmote>>()
+        .await?
+        .value;
 
-    let json = json::parse(&res.text().await?)?;
-    let global_emotes = &json["emotes"];
-
-    let mut emotes_map = HashMap::new();
-
-    for seventv_emotes in [channel_emotes, global_emotes] {
-        if let json::JsonValue::Array(emotes) = seventv_emotes {
-            emotes_map.extend(emotes.iter().map(|emote| {
-                let id = emote["id"].to_string();
-
+    Ok(channel_emotes
+        .into_iter()
+        .chain(global_emotes)
+        .map(|SevenTVEmote { name, id, flags }| {
+            (
+                name,
                 (
-                    emote["name"].to_string(),
-                    (
-                        format!("{id}.webp"),
-                        format!("https://cdn.7tv.app/emote/{id}/1x.webp"),
-                    ),
-                )
-            }));
-        }
-    }
-
-    Ok(emotes_map)
+                    format!("{id}.webp"),
+                    format!("https://cdn.7tv.app/emote/{id}/1x.webp"),
+                    flags == 1,
+                ),
+            )
+        })
+        .collect())
 }
 
-async fn download_emotes(emotes: EmoteMap) -> HashMap<String, String> {
+async fn download_emotes(emotes: EmoteMap) -> HashMap<String, (String, bool)> {
     let client = &Client::new();
 
     // We need to limit the number of concurrent connections, otherwise we might hit some system limits
     // ex: number of files/sockets open, etc.
-    let stream = futures::stream::iter(emotes.into_iter().map(|(x, (filename, url))| async move {
-        let path = cache_path(&filename);
-        let path = Path::new(&path);
+    let stream = futures::stream::iter(emotes.into_iter().map(
+        |(x, (filename, url, o))| async move {
+            let path = cache_path(&filename);
+            let path = Path::new(&path);
 
-        if tokio::fs::metadata(&path).await.is_ok() {
-            return Ok((x, filename));
-        }
+            if tokio::fs::metadata(&path).await.is_ok() {
+                return Ok((x, (filename, o)));
+            }
 
-        let mut res = client.get(&url).send().await?.error_for_status()?;
+            let mut res = client.get(&url).send().await?.error_for_status()?;
 
-        let mut file = tokio::fs::File::create(&path).await?;
+            let mut file = tokio::fs::File::create(&path).await?;
 
-        while let Some(mut item) = res.chunk().await? {
-            file.write_all_buf(item.borrow_mut()).await?;
-        }
+            while let Some(mut item) = res.chunk().await? {
+                file.write_all_buf(item.borrow_mut()).await?;
+            }
 
-        Ok((x, filename))
-    }))
+            Ok((x, (filename, o)))
+        },
+    ))
     .buffer_unordered(100);
 
     stream
-        .collect::<Vec<Result<(String, String)>>>()
+        .collect::<Vec<Result<(String, (String, bool))>>>()
         .await
         .into_iter()
         .filter_map(Result::ok)
         .collect()
 }
 
-pub async fn get_emotes(config: &CompleteConfig, channel: &str) -> Result<HashMap<String, String>> {
+pub async fn get_emotes(
+    config: &CompleteConfig,
+    channel: &str,
+) -> Result<HashMap<String, (String, bool)>> {
     // Reuse the same client and headers for twitch requests
     let twitch_client = get_twitch_client(config).await?;
 


### PR DESCRIPTION
Added support for 7tv zero-width emotes, which are basically just emote overlays.

Switched to `serde_json` instead of `json`. I didn't realize the `json` crate was unmaintained. I'm not really familiar with using serde so there might me a better way to define the structs in `downloader.rs`.

I found a way to avoid the code path in `image` that was causing a panic, so webp emotes should now work.

I have a PR in progress (image-rs/image#1907) that fixes an issue with emotes having a white background, so for now I switched the `image` version to point to my fixed fork. It is probably best to wait for it to get merged and a new version to be released before merging this.
