### PR TITLE
Fix emotes not cleared when scrolling/switching states.

### DIFF
--- a/src/emotes/mod.rs
+++ b/src/emotes/mod.rs
@@ -69,6 +69,19 @@ impl Emotes {
             cell_size,
         })
     }
+
+    pub fn clear(&mut self) {
+        graphics_protocol::command(graphics_protocol::Clear(0, 1)).unwrap_or_default();
+        self.displayed.clear();
+    }
+
+    pub fn unload(&mut self) {
+        graphics_protocol::command(graphics_protocol::Clear(0, 0)).unwrap_or_default();
+        self.emotes.clear();
+        self.loaded.clear();
+        self.info.clear();
+        self.displayed.clear();
+    }
 }
 
 #[inline]
@@ -284,20 +297,6 @@ pub fn reload_emote(
     graphics_protocol::command(graphics_protocol::Load::new(hash, &cache_path(filename))?)?;
     loaded_emotes.insert(hash);
     Ok(())
-}
-
-pub fn unload_all_emotes(emotes: &mut Emotes) {
-    graphics_protocol::command(graphics_protocol::Clear(0, 0)).unwrap_or_default();
-    emotes.emotes.clear();
-    emotes.loaded.clear();
-    emotes.info.clear();
-    emotes.displayed.clear();
-}
-
-#[allow(dead_code)]
-pub fn hide_all_emotes(emotes: &mut Emotes) {
-    graphics_protocol::command(graphics_protocol::Clear(0, 1)).unwrap_or_default();
-    emotes.displayed.clear();
 }
 
 pub fn show_span_emotes<F>(

--- a/src/handlers/app.rs
+++ b/src/handlers/app.rs
@@ -47,6 +47,8 @@ pub struct App {
     pub buffer_suggestion: Option<String>,
     /// The theme selected by the user.
     pub theme: Theme,
+    /// Emotes
+    pub emotes: Emotes,
 }
 
 macro_rules! shared {
@@ -94,10 +96,11 @@ impl App {
             input_buffer: LineBuffer::with_capacity(LINE_BUFFER_CAPACITY),
             buffer_suggestion: None,
             theme: shared_config_borrow.frontend.theme.clone(),
+            emotes: Emotes::default(),
         }
     }
 
-    pub fn draw<B: Backend>(&mut self, f: &mut Frame<B>, emotes: Emotes) {
+    pub fn draw<B: Backend>(&mut self, f: &mut Frame<B>) {
         let mut size = f.size();
 
         if self.config.borrow().frontend.state_tabs {
@@ -116,7 +119,7 @@ impl App {
         } else {
             match self.state {
                 State::Dashboard => self.components.dashboard.draw(f, size, None),
-                State::Normal => self.components.chat.draw(f, size, Some(emotes)),
+                State::Normal => self.components.chat.draw(f, size, Some(&mut self.emotes)),
                 State::Help => self.components.help.draw(f, size, None),
             }
         }
@@ -158,6 +161,7 @@ impl App {
     }
 
     pub fn clear_messages(&mut self) {
+        self.emotes.clear();
         self.messages.borrow_mut().clear();
 
         self.components.chat.scroll_offset.jump_to(0);
@@ -173,6 +177,7 @@ impl App {
     }
 
     pub fn set_state(&mut self, other: State) {
+        self.emotes.clear();
         self.previous_state = Some(self.state.clone());
         self.state = other;
     }

--- a/src/ui/components/channel_switcher.rs
+++ b/src/ui/components/channel_switcher.rs
@@ -78,7 +78,7 @@ impl ToString for ChannelSwitcherWidget {
 }
 
 impl Component for ChannelSwitcherWidget {
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<&mut Emotes>) {
         self.input.draw(f, area, emotes);
     }
 

--- a/src/ui/components/chat.rs
+++ b/src/ui/components/chat.rs
@@ -73,7 +73,7 @@ impl ChatWidget {
         frame: &mut Frame<B>,
         area: Rect,
         messages_data: &'a VecDeque<MessageData>,
-        mut emotes: Emotes,
+        emotes: &mut Emotes,
     ) -> VecDeque<Line<'a>> {
         // Accounting for not all heights of rows to be the same due to text wrapping,
         // so extra space needs to be used in order to scroll correctly.
@@ -154,7 +154,7 @@ impl ChatWidget {
                         match show_span_emotes(
                             &data.emotes,
                             &mut span,
-                            &mut emotes,
+                            emotes,
                             &payload,
                             self.config.borrow().frontend.margin as usize,
                             current_row as u16,
@@ -201,9 +201,9 @@ impl ChatWidget {
 }
 
 impl Component for ChatWidget {
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<&mut Emotes>) {
         // TODO: Don't let this be a thing
-        let mut emotes = emotes.unwrap();
+        let emotes = emotes.unwrap();
 
         let config = self.config.borrow();
 
@@ -238,7 +238,7 @@ impl Component for ChatWidget {
 
         let messages_data = self.messages.clone().borrow().to_owned();
 
-        let messages = self.get_messages(f, *first_v_chunk, &messages_data, emotes.clone());
+        let messages = self.get_messages(f, *first_v_chunk, &messages_data, emotes);
 
         let current_time = Local::now()
             .format(&config.frontend.date_format)

--- a/src/ui/components/chat_input.rs
+++ b/src/ui/components/chat_input.rs
@@ -91,7 +91,7 @@ impl ToString for ChatInputWidget {
 }
 
 impl Component for ChatInputWidget {
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<&mut Emotes>) {
         self.input.draw(f, area, emotes);
     }
 

--- a/src/ui/components/dashboard.rs
+++ b/src/ui/components/dashboard.rs
@@ -165,7 +165,7 @@ impl DashboardWidget {
 }
 
 impl Component for DashboardWidget {
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<&mut Emotes>) {
         let start_screen_channels_len =
             self.config.borrow().frontend.start_screen_channels.len() as u16;
 

--- a/src/ui/components/debug.rs
+++ b/src/ui/components/debug.rs
@@ -37,7 +37,7 @@ impl DebugWidget {
 }
 
 impl Component for DebugWidget {
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, _emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, _emotes: Option<&mut Emotes>) {
         // TODO: Add more debug stuff
         let config = self.config.borrow();
 

--- a/src/ui/components/error.rs
+++ b/src/ui/components/error.rs
@@ -25,7 +25,7 @@ impl ErrorWidget {
 }
 
 impl Component for ErrorWidget {
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, _emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, _emotes: Option<&mut Emotes>) {
         let paragraph = Paragraph::new(
             WINDOW_SIZE_ERROR_MESSAGE
                 .iter()

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -32,7 +32,7 @@ impl HelpWidget {
 }
 
 impl Component for HelpWidget {
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, _emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, _emotes: Option<&mut Emotes>) {
         let mut rows = vec![];
 
         for (s, v) in HELP_KEYBINDS.iter() {

--- a/src/ui/components/message_search.rs
+++ b/src/ui/components/message_search.rs
@@ -58,7 +58,7 @@ impl ToString for MessageSearchWidget {
 }
 
 impl Component for MessageSearchWidget {
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<&mut Emotes>) {
         self.input.draw(f, area, emotes);
     }
 

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -36,7 +36,7 @@ use crate::{
 
 pub trait Component {
     #[allow(unused_variables)]
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, emotes: Option<&mut Emotes>) {
         todo!()
     }
 

--- a/src/ui/components/utils/insert_box.rs
+++ b/src/ui/components/utils/insert_box.rs
@@ -81,7 +81,7 @@ impl ToString for InputWidget {
 }
 
 impl Component for InputWidget {
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, _emotes: Option<Emotes>) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect, _emotes: Option<&mut Emotes>) {
         let cursor_pos = get_cursor_position(&self.input);
 
         f.set_cursor(


### PR DESCRIPTION
With the 0.24 update emotes were broken.
They can't be cloned as the state of the Emote struct needs to be persistent across each app drawing.

I've cleaned up a bit the emote clearing code when switching state/channels.

I'm also still waiting on the release of image-rs 0.24.7 for the white background fix.