### PR TITLE
Switch to using unicode placeholders to display emotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,6 +2428,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 name = "twitch-tui"
 version = "2.6.1"
 dependencies = [
+ "anyhow",
  "base64",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,12 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,7 +2422,6 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 name = "twitch-tui"
 version = "2.6.1"
 dependencies = [
- "anyhow",
  "base64",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 crossterm = "0.27.0"
-tui = { package = "ratatui", version = "0.24.0", default-features = false, features = [ "crossterm", "serde" ] }
+tui = { package = "ratatui", version = "0.24.0", default-features = false, features = [ "crossterm", "serde", "underline-color" ] }
 tokio = { version = "1.34.0", features = [ "rt", "macros", "rt-multi-thread", "fs" ] }
 clap = { version = "4.4.8", features = [ "derive", "cargo" ] }
 serde = { version = "1.0.192", features = [ "derive" ] }
@@ -40,6 +40,7 @@ tempfile = "3.8.1"
 serde_with = "3.4.0"
 once_cell = "1.18.0"
 webbrowser = "0.8.12"
+anyhow = "1.0.75"
 
 [[bin]]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ tempfile = "3.8.1"
 serde_with = "3.4.0"
 once_cell = "1.18.0"
 webbrowser = "0.8.12"
-anyhow = "1.0.75"
 
 [[bin]]
 bench = false

--- a/src/emotes/graphics_protocol.rs
+++ b/src/emotes/graphics_protocol.rs
@@ -1,25 +1,23 @@
+use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
-use color_eyre::eyre::{anyhow, ContextCompat};
-use crossterm::{csi, cursor::MoveTo, queue, Command};
+use crossterm::{csi, queue, Command};
 use dialoguer::console::{Key, Term};
 use image::{
     codecs::{gif::GifDecoder, webp::WebPDecoder},
+    imageops::FilterType,
     io::Reader,
-    AnimationDecoder, ImageDecoder, ImageFormat, Rgba,
+    AnimationDecoder, DynamicImage, GenericImageView, ImageDecoder, ImageFormat, Rgba,
 };
 use std::{
+    cmp::min,
     env, fmt, fs,
     fs::File,
     io::{BufReader, Write},
-    mem,
     path::PathBuf,
 };
 
-use crate::{
-    handlers::data::EmoteData,
-    utils::pathing::{
-        create_temp_file, pathbuf_try_to_string, remove_temp_file, save_in_temp_file,
-    },
+use crate::utils::pathing::{
+    create_temp_file, pathbuf_try_to_string, remove_temp_file, save_in_temp_file,
 };
 
 /// Macro to add the graphics protocol escape sequence around a command.
@@ -34,10 +32,21 @@ macro_rules! gp {
 /// string to be deleted by the terminal.
 const GP_PREFIX: &str = "twt.tty-graphics-protocol.";
 
-type Result<T = ()> = color_eyre::Result<T>;
-
 pub trait Size {
-    fn size(&self) -> (u32, u32);
+    fn width(&self) -> u32;
+
+    fn calculate_new_size(
+        (width, height): (u32, u32),
+        (_cell_w, cell_h): (f32, f32),
+    ) -> (u32, u32) {
+        // Resize width to fit image in 1 cell of height
+        let new_width = (width as f32 * cell_h / height as f32).ceil();
+        (new_width as u32, cell_h as u32)
+    }
+
+    fn calculate_resize_ratio((_width, height): (u32, u32), (_cell_w, cell_h): (f32, f32)) -> f32 {
+        cell_h / height as f32
+    }
 }
 
 pub struct StaticImage {
@@ -48,11 +57,14 @@ pub struct StaticImage {
 }
 
 impl StaticImage {
-    pub fn new(id: u32, image: Reader<BufReader<File>>) -> Result<Self> {
-        let image = image.decode()?.to_rgba8();
+    pub fn new(id: u32, image: Reader<BufReader<File>>, cell_size: (f32, f32)) -> Result<Self> {
+        let image = image.decode()?;
         let (width, height) = image.dimensions();
+        let (width, height) = Self::calculate_new_size((width, height), cell_size);
+        let image = image.resize(width, height, FilterType::Lanczos3);
+
         let (mut tempfile, pathbuf) = create_temp_file(GP_PREFIX)?;
-        if let Err(e) = save_in_temp_file(image.as_raw(), &mut tempfile) {
+        if let Err(e) = save_in_temp_file(image.to_rgba8().as_raw(), &mut tempfile) {
             remove_temp_file(&pathbuf);
             return Err(e);
         }
@@ -85,8 +97,8 @@ impl Command for StaticImage {
 }
 
 impl Size for StaticImage {
-    fn size(&self) -> (u32, u32) {
-        (self.width, self.height)
+    fn width(&self) -> u32 {
+        self.width
     }
 }
 
@@ -98,27 +110,40 @@ pub struct AnimatedImage {
 }
 
 impl AnimatedImage {
-    pub fn new<'a>(id: u32, decoder: impl ImageDecoder<'a> + AnimationDecoder<'a>) -> Result<Self> {
+    pub fn new<'a>(
+        id: u32,
+        decoder: impl ImageDecoder<'a> + AnimationDecoder<'a>,
+        cell_size: (f32, f32),
+    ) -> Result<Self> {
         let (width, height) = decoder.dimensions();
-        let frames = decoder.into_frames().collect_frames()?;
-        let iter = frames.iter();
+        let resize_ratio = Self::calculate_resize_ratio((width, height), cell_size);
+        let (width, height) = Self::calculate_new_size((width, height), cell_size);
+        let frames = decoder.into_frames();
 
-        let (ok, err): (Vec<_>, Vec<_>) = iter
+        let (ok, err): (Vec<_>, Vec<_>) = frames
             .map(|f| {
+                let frame = f?;
+                let delay = frame.delay().numer_denom_ms().0;
+                let image = DynamicImage::from(frame.into_buffer());
+                let (w, h) = image.dimensions();
+                let image = image.resize(
+                    min((w as f32 * resize_ratio).ceil() as u32, width),
+                    min((h as f32 * resize_ratio).ceil() as u32, height),
+                    FilterType::Lanczos3,
+                );
                 let (mut tempfile, pathbuf) = create_temp_file(GP_PREFIX)?;
-                save_in_temp_file(f.buffer().as_raw(), &mut tempfile)?;
-                let delay = f.delay().numer_denom_ms().0;
+                save_in_temp_file(image.to_rgba8().as_raw(), &mut tempfile)?;
 
-                Ok((pathbuf, delay))
+                Ok::<(PathBuf, u32), anyhow::Error>((pathbuf, delay))
             })
             .partition(Result::is_ok);
 
-        let frames: Vec<(PathBuf, u32)> = ok.into_iter().filter_map(Result::ok).collect();
+        let frames: Vec<(PathBuf, u32)> = ok.into_iter().flatten().collect();
 
         // If we had any error, we need to delete the temp files, as the terminal won't do it for us.
         if !err.is_empty() {
             for (path, _) in &frames {
-                mem::drop(fs::remove_file(path));
+                drop(fs::remove_file(path));
             }
             return Err(anyhow!("Invalid frame in gif."));
         }
@@ -147,6 +172,7 @@ impl Command for AnimatedImage {
         // We need to send the data for the first frame as a normal image.
         // We can unwrap here because we checked above if frames was empty.
         let (path, delay) = frames.next().unwrap();
+
         write!(
             f,
             gp!("a=t,t=t,f=32,s={width},v={height},i={id},q=2;{path}"),
@@ -186,8 +212,8 @@ impl Command for AnimatedImage {
 }
 
 impl Size for AnimatedImage {
-    fn size(&self) -> (u32, u32) {
-        (self.width, self.height)
+    fn width(&self) -> u32 {
+        self.width
     }
 }
 
@@ -197,7 +223,7 @@ pub enum Load {
 }
 
 impl Load {
-    pub fn new(id: u32, path: &str) -> Result<Self> {
+    pub fn new(id: u32, path: &str, cell_size: (f32, f32)) -> Result<Self> {
         let path = std::path::PathBuf::from(path);
         let image = Reader::open(&path)?.with_guessed_format()?;
 
@@ -210,18 +236,18 @@ impl Load {
                     // Some animated webp images have a default white background color
                     // We replace it by a transparent background
                     decoder.set_background_color(Rgba([0, 0, 0, 0]))?;
-                    Ok(Self::Animated(AnimatedImage::new(id, decoder)?))
+                    Ok(Self::Animated(AnimatedImage::new(id, decoder, cell_size)?))
                 } else {
                     let image = Reader::open(&path)?.with_guessed_format()?;
 
-                    Ok(Self::Static(StaticImage::new(id, image)?))
+                    Ok(Self::Static(StaticImage::new(id, image, cell_size)?))
                 }
             }
             Some(ImageFormat::Gif) => {
                 let decoder = GifDecoder::new(image.into_inner())?;
-                Ok(Self::Animated(AnimatedImage::new(id, decoder)?))
+                Ok(Self::Animated(AnimatedImage::new(id, decoder, cell_size)?))
             }
-            Some(_) => Ok(Self::Static(StaticImage::new(id, image)?)),
+            Some(_) => Ok(Self::Static(StaticImage::new(id, image, cell_size)?)),
         }
     }
 }
@@ -241,55 +267,99 @@ impl Command for Load {
 }
 
 impl Size for Load {
-    fn size(&self) -> (u32, u32) {
+    fn width(&self) -> u32 {
         match self {
-            Self::Static(s) => s.size(),
-            Self::Animated(a) => a.size(),
+            Self::Static(s) => s.width(),
+            Self::Animated(a) => a.width(),
         }
     }
 }
 
+pub struct Clear;
+
+impl Command for Clear {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(f, gp!("a=d,d=A,q=2;"))
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> std::result::Result<(), std::io::Error> {
+        panic!("Windows version not supported.")
+    }
+}
+
 pub struct Display {
-    x: u16,
-    y: u16,
     id: u32,
     pid: u32,
-    width: u16,
-    offset: u16,
-    layer: u16,
+    cols: u16,
 }
 
 impl Display {
-    pub const fn new(
-        (x, y): (u16, u16),
-        EmoteData { id, pid, layer, .. }: &EmoteData,
-        width: u16,
-        offset: u16,
-    ) -> Self {
-        Self {
-            x,
-            y,
-            id: *id,
-            pid: *pid,
-            width,
-            offset,
-            layer: *layer,
-        }
+    pub const fn new(id: u32, pid: u32, cols: u16) -> Self {
+        Self { id, pid, cols }
     }
 }
 
 impl Command for Display {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        MoveTo(self.x, self.y).write_ansi(f)?;
         // r=1: Set height to 1 row
         write!(
             f,
-            gp!("a=p,i={id},p={pid},r=1,c={width},X={offset},z={z},q=2;"),
+            gp!("a=p,U=1,i={id},p={pid},r=1,c={cols},q=2;"),
             id = self.id,
             pid = self.pid,
-            width = self.width,
-            offset = self.offset,
-            z = self.layer
+            cols = self.cols
+        )
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> std::result::Result<(), std::io::Error> {
+        panic!("Windows version not supported.")
+    }
+}
+pub struct Chain {
+    id: u32,
+    pid: u32,
+    parent_id: u32,
+    parent_placement_id: u32,
+    z: u32,
+    col_offset: u16,
+    pixel_offset: u16,
+}
+
+impl Chain {
+    pub const fn new(
+        id: u32,
+        pid: u32,
+        (parent_id, parent_placement_id): (u32, u32),
+        z: u32,
+        col_offset: u16,
+        pixel_offset: u16,
+    ) -> Self {
+        Self {
+            id,
+            pid,
+            parent_id,
+            parent_placement_id,
+            z,
+            col_offset,
+            pixel_offset,
+        }
+    }
+}
+
+impl Command for Chain {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(
+            f,
+            gp!("a=p,i={id},p={pid},P={parent_id},Q={parent_pid},z={z},H={co},X={pxo},q=2;"),
+            id = self.id,
+            pid = self.pid,
+            parent_id = self.parent_id,
+            parent_pid = self.parent_placement_id,
+            z = self.z,
+            co = self.col_offset,
+            pxo = self.pixel_offset
         )
     }
 
@@ -299,32 +369,13 @@ impl Command for Display {
     }
 }
 
-#[derive(Eq, PartialEq)]
-pub struct Clear(pub u32, pub u32);
-
-impl Command for Clear {
-    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        if *self == Self(0, 0) {
-            // Delete and unload all images
-            write!(f, gp!("a=d,d=A,q=2;"))
-        } else if self.0 == 0 {
-            // Delete all images
-            write!(f, gp!("a=d,d=a,q=2;"))
-        } else {
-            write!(
-                f,
-                gp!("a=d,d=i,i={id},p={pid},q=2;"),
-                id = self.0,
-                pid = self.1,
-            )
-        }
-    }
-
-    #[cfg(windows)]
-    fn execute_winapi(&self) -> std::result::Result<(), std::io::Error> {
-        panic!("Windows version not supported.")
+pub trait ApplyCommand: Command {
+    fn apply(&self) -> Result<()> {
+        Ok(queue!(std::io::stdout(), self)?)
     }
 }
+
+impl<T: Command> ApplyCommand for T {}
 
 /// Send a csi query to the terminal. The terminal must respond in the format `<ESC>[(a)(r)(c)`,
 /// where `(a)` can be any character, `(r)` is the terminal response, and `(c)` is the last character of the query.
@@ -339,8 +390,7 @@ fn query_terminal(command: &[u8]) -> Result<String> {
 
     // Empty stdout buffer until we find the terminal response.
     loop {
-        let c = stdout.read_key()?;
-        if let Key::UnknownEscSeq(_) = c {
+        if let Key::UnknownEscSeq(_) = stdout.read_key()? {
             break;
         }
     }
@@ -357,44 +407,17 @@ fn query_terminal(command: &[u8]) -> Result<String> {
     Ok(response)
 }
 
-pub fn get_terminal_cell_size() -> Result<(u16, u16)> {
-    // Request the terminal size in pixels.
-    let res = query_terminal(csi!("14t").as_bytes())?;
-
-    // Response has the format <height>;<width>
-    let mut values = res.split(';');
-    let height_px = values
-        .next()
-        .context("Invalid response from terminal")?
-        .parse::<u16>()?;
-    let width_px = values
-        .next()
-        .context("Invalid response from terminal")?
-        .parse::<u16>()?;
-
-    // Size of terminal: (columns, rows)
-    let (ncols, nrows) = crossterm::terminal::size()?;
-
-    Ok((width_px / ncols, height_px / nrows))
-}
-
-/// First check if the terminal is `kitty` or `WezTerm`, theses are the only terminals that fully support the graphics protocol as of 2023-04-09.
+/// First check if the terminal is `kitty`, this is the only terminal that supports the graphics protocol using unicode placeholders as of 2023-07-13.
 /// Then check that it supports the graphics protocol using temporary files, by sending a graphics protocol request followed by a request for terminal attributes.
 /// If we receive the terminal attributes without receiving the response for the graphics protocol, it does not support it.
 pub fn support_graphics_protocol() -> Result<bool> {
-    Ok(
-        (env::var("TERM")? == "xterm-kitty" || env::var("TERM_PROGRAM")? == "WezTerm")
-            && query_terminal(
-                format!(
-                    concat!(gp!("i=31,s=1,v=1,a=q,t=d,f=24;{}"), csi!("c")),
-                    STANDARD.encode("AAAA"),
-                )
-                .as_bytes(),
-            )?
-            .contains("OK"),
-    )
-}
-
-pub fn command(c: impl Command) -> Result {
-    Ok(queue!(std::io::stdout(), c)?)
+    Ok(env::var("TERM")? == "xterm-kitty"
+        && query_terminal(
+            format!(
+                concat!(gp!("i=31,s=1,v=1,a=q,t=d,f=24;{}"), csi!("c")),
+                STANDARD.encode("AAAA"),
+            )
+            .as_bytes(),
+        )?
+        .contains("OK"))
 }

--- a/src/emotes/mod.rs
+++ b/src/emotes/mod.rs
@@ -1,26 +1,20 @@
-use color_eyre::{eyre::ContextCompat, Result};
 use log::{info, warn};
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap, HashSet},
+    collections::{hash_map::DefaultHasher, HashMap},
     hash::{Hash, Hasher},
 };
 
-use tokio::sync::{broadcast::Receiver, mpsc::Sender};
-use tui::{
-    layout::Rect,
-    text::{Line, Span},
-};
-use unicode_width::UnicodeWidthStr;
-
 use crate::{
-    emotes::{downloader::get_emotes, graphics_protocol::Size},
-    handlers::{
-        config::{CompleteConfig, FrontendConfig},
-        data::EmoteData,
+    emotes::{
+        downloader::get_emotes,
+        graphics_protocol::{ApplyCommand, Size},
     },
+    handlers::config::{CompleteConfig, FrontendConfig},
     twitch::TwitchAction,
     utils::pathing::cache_path,
 };
+use anyhow::Result;
+use tokio::sync::{broadcast::Receiver, mpsc::Sender};
 
 mod downloader;
 pub mod graphics_protocol;
@@ -28,16 +22,21 @@ pub mod graphics_protocol;
 // HashMap of emote name, emote filename, and if the emote is an overlay
 pub type DownloadedEmotes = HashMap<String, (String, bool)>;
 
+#[derive(Copy, Clone, Debug)]
+pub struct EmoteData {
+    pub width: u32,
+    pub id: u32,
+    pub pid: u32,
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct LoadedEmote {
     /// Hash of the emote filename, used as an ID for displaying the image
     pub hash: u32,
     /// Number of emotes that have been displayed
     pub n: u32,
-    /// Width in cells of the emote
-    pub width: u16,
-    /// Offset is the difference between the emote width in pixels, and the edge of the next cell
-    pub offset: u16,
+    /// Width of the emote in pixels
+    pub width: u32,
     /// If the emote should be displayed over the previous emote, if no text is between them.
     pub overlay: bool,
 }
@@ -46,39 +45,33 @@ pub struct LoadedEmote {
 pub struct Emotes {
     /// Map of emote name, filename, and if the emote is an overlay
     pub emotes: DownloadedEmotes,
-    /// Emotes currently loaded
-    pub loaded: HashSet<u32>,
     /// Info about loaded emotes
     pub info: HashMap<String, LoadedEmote>,
-    /// Emotes currently displayed: (id, placement id), (col, row)
-    pub displayed: HashMap<(u32, u32), (u16, u16)>,
     /// Terminal cell size in pixels: (width, height)
-    pub cell_size: (u16, u16),
+    pub cell_size: (f32, f32),
 }
 
 impl Emotes {
-    pub fn clear(&mut self) {
-        graphics_protocol::command(graphics_protocol::Clear(0, 1)).unwrap_or_default();
-        self.displayed.clear();
-    }
-
     pub fn unload(&mut self) {
-        graphics_protocol::command(graphics_protocol::Clear(0, 0)).unwrap_or_default();
+        graphics_protocol::Clear.apply().unwrap_or_default();
         self.emotes.clear();
-        self.loaded.clear();
         self.info.clear();
-        self.displayed.clear();
+    }
+}
+
+impl From<LoadedEmote> for EmoteData {
+    fn from(LoadedEmote { hash, n, width, .. }: LoadedEmote) -> Self {
+        Self {
+            id: hash,
+            pid: n,
+            width,
+        }
     }
 }
 
 #[inline]
 pub const fn emotes_enabled(frontend: &FrontendConfig) -> bool {
     frontend.twitch_emotes || frontend.betterttv_emotes || frontend.seventv_emotes
-}
-
-#[inline]
-pub const fn is_in_rect(rect: Rect, (x, y): (u16, u16), width: u16) -> bool {
-    y < rect.bottom() && y > rect.top() - 1 && x < rect.right() && x + width > rect.left()
 }
 
 pub async fn send_emotes(config: &CompleteConfig, tx: &Sender<DownloadedEmotes>, channel: &str) {
@@ -110,124 +103,12 @@ pub async fn emotes(
     }
 }
 
-pub fn show_emotes<F>(
-    message_emotes: &Vec<EmoteData>,
-    span: &mut Span,
-    emotes: &mut Emotes,
-    prefix_width: usize,
-    // Payload start/end index in span content
-    (start, end): (usize, usize),
-    row: u16,
-    hide: F,
-) where
-    F: Fn((u16, u16), u16) -> bool,
-{
-    let mut emotes_pos_in_span = HashSet::new();
-
-    for emote in message_emotes {
-        // Emote is on a further row, we can exit now
-        if emote.index_in_message > end {
-            break;
-        }
-        // Emote is on a previous row
-        if emote.index_in_message < start {
-            continue;
-        }
-
-        let col = (emote.index_in_message + prefix_width - start) as u16;
-
-        emotes_pos_in_span.insert(emote.index_in_message - start);
-
-        let Some(info) = emotes.info.get(&emote.name) else {
-            warn!("Unable to get info of emote {}", emote.name);
-            continue;
-        };
-
-        // Delete emote if we don't need to display it
-        if hide((col, row), info.width) {
-            if let Err(err) =
-                graphics_protocol::command(graphics_protocol::Clear(emote.id, emote.pid))
-            {
-                warn!("Unable to delete emote {}: {err}", emote.name);
-            } else {
-                emotes.displayed.remove(&(emote.id, emote.pid));
-            }
-            continue;
-        }
-
-        if !emotes.loaded.contains(&emote.id)
-            && reload_emote(&emotes.emotes, &mut emotes.loaded, &emote.name, emote.id).is_err()
-        {
-            continue;
-        }
-
-        // Only send a command if the emote changed position
-        if emotes.displayed.get(&(emote.id, emote.pid)) != Some(&(col, row)) {
-            if let Err(err) = graphics_protocol::command(graphics_protocol::Display::new(
-                (col, row),
-                emote,
-                info.width,
-                info.offset,
-            )) {
-                warn!("Unable to display emote {}: {err:?}", emote.name);
-            }
-        }
-
-        emotes.displayed.insert((emote.id, emote.pid), (col, row));
-    }
-
-    update_span_content(span, &emotes_pos_in_span);
-}
-
-/// Replace span content at emote position with spaces
-pub fn update_span_content(span: &mut Span, positions: &HashSet<usize>) {
-    if positions.is_empty() {
-        return;
-    }
-
-    let mut words: Vec<String> = span.content.split(' ').map(ToString::to_string).collect();
-    let mut string_position = 0;
-    let mut word_idx = 0;
-
-    while word_idx < words.len() {
-        let word = &mut words[word_idx];
-        word_idx += 1;
-
-        if positions.contains(&string_position) {
-            *word = " ".repeat(word.width());
-        }
-
-        string_position += word.width() + 1;
-    }
-
-    *span.content.to_mut() = words.join(" ");
-}
-
-pub fn hide_message_emotes(
-    emotes: &Vec<EmoteData>,
-    displayed: &mut HashMap<(u32, u32), (u16, u16)>,
-    pos: usize,
-) {
-    for emote in emotes {
-        if displayed.contains_key(&(emote.id, emote.pid)) && emote.index_in_message < pos {
-            if let Err(err) =
-                graphics_protocol::command(graphics_protocol::Clear(emote.id, emote.pid))
-            {
-                warn!("Unable to delete emote {}: {err}", emote.name);
-            } else {
-                displayed.remove(&(emote.id, emote.pid));
-            }
-        }
-    }
-}
-
 pub fn load_emote(
     word: &str,
     filename: &str,
     overlay: bool,
     info: &mut HashMap<String, LoadedEmote>,
-    loaded: &mut HashSet<u32>,
-    (cell_w, cell_h): (u16, u16),
+    cell_size: (f32, f32),
 ) -> Result<LoadedEmote> {
     if let Some(emote) = info.get_mut(word) {
         emote.n += 1;
@@ -235,75 +116,44 @@ pub fn load_emote(
     } else {
         let mut hasher = DefaultHasher::new();
         word.hash(&mut hasher);
-        let hash = hasher.finish() as u32;
+        // ID is encoded on 3 bytes, discard the first one.
+        let hash = hasher.finish() as u32 & 0x00FF_FFFF;
 
         // Tells the terminal to load the image for later use
-        let loaded_image = graphics_protocol::Load::new(hash, &cache_path(filename))?;
-        let (width_px, height_px) = loaded_image.size();
-        graphics_protocol::command(loaded_image)?;
+        let loaded_image = graphics_protocol::Load::new(hash, &cache_path(filename), cell_size)?;
+        let width = loaded_image.width();
+        loaded_image.apply()?;
 
-        let mut width_px = width_px as f32;
-        let cell_w = u32::from(cell_w);
-        // Resize width to fit image in 1 cell of height
-        width_px = (width_px * f32::from(cell_h) / height_px as f32).ceil();
-        // Offset the image on the left side, otherwise the terminal will stretch it
-        let offset = ((width_px as u32 % cell_w).abs_diff(cell_w) % cell_w) as u16;
-        let width_cell = (width_px / cell_w as f32).ceil() as u16;
         let emote = LoadedEmote {
             hash,
             n: 1,
-            width: width_cell,
-            offset,
+            width,
             overlay,
         };
 
         info.insert(word.to_string(), emote);
-        loaded.insert(hash);
         Ok(emote)
     }
 }
 
-pub fn reload_emote(
-    emote_list: &HashMap<String, (String, bool)>,
-    loaded_emotes: &mut HashSet<u32>,
-    name: &str,
-    hash: u32,
-) -> Result<()> {
-    let (filename, _) = emote_list.get(name).context("Emote not found")?;
-    graphics_protocol::command(graphics_protocol::Load::new(hash, &cache_path(filename))?)?;
-    loaded_emotes.insert(hash);
-    Ok(())
+pub fn display_emote(id: u32, pid: u32, cols: u16) -> Result<()> {
+    graphics_protocol::Display::new(id, pid, cols).apply()
 }
 
-pub fn show_span_emotes<F>(
-    message_emotes: &Vec<EmoteData>,
-    line: &mut Line,
-    emotes: &mut Emotes,
-    payload: &str,
-    margin: usize,
-    current_row: u16,
-    hide: F,
-) -> Result<String>
-where
-    F: Fn((u16, u16), u16) -> bool,
-{
-    let span_width: usize = line.spans.iter().map(|s| s.content.width()).sum();
-    let last_span = line.spans.last_mut().context("Span is empty")?;
-
-    let p = payload
-        .trim_end()
-        .strip_suffix(last_span.content.trim_end())
-        .context("Unable to find span content in payload")?;
-
-    show_emotes(
-        message_emotes,
-        last_span,
-        emotes,
-        span_width + margin + 1 - last_span.content.width(),
-        (p.width(), payload.width() - 1),
-        current_row,
-        hide,
+pub fn overlay_emote(
+    parent: (u32, u32),
+    emote: &EmoteData,
+    layer: u32,
+    full_width: f32,
+    cell_width: f32,
+) -> Result<()> {
+    // Center the overlay on top of the emote
+    let pixel_offset = (full_width - emote.width as f32) / 2.0;
+    let (col_offset, pixel_offset) = (
+        (pixel_offset / cell_width) as u16,
+        (pixel_offset % cell_width) as u16,
     );
 
-    Ok(p.to_string())
+    graphics_protocol::Chain::new(emote.id, emote.pid, parent, layer, col_offset, pixel_offset)
+        .apply()
 }

--- a/src/emotes/mod.rs
+++ b/src/emotes/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     twitch::TwitchAction,
     utils::pathing::cache_path,
 };
-use anyhow::Result;
+use color_eyre::Result;
 use tokio::sync::{broadcast::Receiver, mpsc::Sender};
 
 mod downloader;
@@ -144,14 +144,14 @@ pub fn overlay_emote(
     parent: (u32, u32),
     emote: &EmoteData,
     layer: u32,
-    full_width: f32,
+    root_width: u32,
     cell_width: f32,
 ) -> Result<()> {
     // Center the overlay on top of the emote
-    let pixel_offset = (full_width - emote.width as f32) / 2.0;
+    let pixel_offset = (root_width as f32 - emote.width as f32) / 2.0;
     let (col_offset, pixel_offset) = (
-        (pixel_offset / cell_width) as u16,
-        (pixel_offset % cell_width) as u16,
+        (pixel_offset / cell_width) as i16,
+        pixel_offset.rem_euclid(cell_width) as u16,
     );
 
     graphics_protocol::Chain::new(emote.id, emote.pid, parent, layer, col_offset, pixel_offset)

--- a/src/handlers/app.rs
+++ b/src/handlers/app.rs
@@ -118,14 +118,12 @@ impl App {
         if (size.height < 10 || size.width < 60)
             && self.config.borrow().frontend.show_unsupported_screen_size
         {
-            self.components
-                .window_size_error
-                .draw(f, Some(f.size()), None);
+            self.components.window_size_error.draw(f, Some(f.size()));
         } else {
             match self.state {
-                State::Dashboard => self.components.dashboard.draw(f, None, None),
-                State::Normal => self.components.chat.draw(f, None, Some(&mut self.emotes)),
-                State::Help => self.components.help.draw(f, None, None),
+                State::Dashboard => self.components.dashboard.draw(f, None),
+                State::Normal => self.components.chat.draw(f, None),
+                State::Help => self.components.help.draw(f, None),
             }
         }
 
@@ -137,7 +135,7 @@ impl App {
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
                 .split(new_rect)[1];
 
-            self.components.debug.draw(f, Some(rect), None);
+            self.components.debug.draw(f, Some(rect));
         }
     }
 
@@ -170,7 +168,6 @@ impl App {
     }
 
     pub fn clear_messages(&mut self) {
-        self.emotes.clear();
         self.messages.borrow_mut().clear();
 
         self.components.chat.scroll_offset.jump_to(0);
@@ -210,7 +207,6 @@ impl App {
     }
 
     pub fn set_state(&mut self, other: State) {
-        self.emotes.clear();
         self.previous_state = Some(self.state.clone());
         self.state = other;
     }

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -360,22 +360,17 @@ impl MessageData {
                 Emote(v) => {
                     let max_width = v.iter().max_by_key(|e| e.width)?.width as f32;
                     let cols = (max_width / emotes.cell_size.0).ceil() as u16;
-                    let full_width = f32::from(cols) * emotes.cell_size.0;
 
-                    let &EmoteData { id, pid, .. } = v.first()?;
+                    let &EmoteData { id, pid, width } = v.first()?;
                     if let Err(e) = display_emote(id, pid, cols) {
                         warn!("Unable to display emote: {e}");
                         return None;
                     }
 
                     v.iter().enumerate().skip(1).for_each(|(layer, emote)| {
-                        if let Err(e) = overlay_emote(
-                            (id, pid),
-                            emote,
-                            layer as u32,
-                            full_width,
-                            emotes.cell_size.0,
-                        ) {
+                        if let Err(e) =
+                            overlay_emote((id, pid), emote, layer as u32, width, emotes.cell_size.0)
+                        {
                             warn!("Unable to display overlay: {e}");
                         }
                     });

--- a/src/ui/components/channel_switcher.rs
+++ b/src/ui/components/channel_switcher.rs
@@ -15,7 +15,6 @@ use tui::{
 };
 
 use crate::{
-    emotes::Emotes,
     handlers::{
         config::SharedCompleteConfig,
         storage::SharedStorage,
@@ -141,7 +140,7 @@ impl ToString for ChannelSwitcherWidget {
 }
 
 impl Component for ChannelSwitcherWidget {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, emotes: Option<&mut Emotes>) {
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
         let r = area.map_or_else(|| centered_rect(60, 60, 20, f.size()), |a| a);
 
         let channels = self.storage.borrow().get("channels");
@@ -252,7 +251,7 @@ impl Component for ChannelSwitcherWidget {
 
         let input_rect = Rect::new(r.x, r.bottom(), r.width, 3);
 
-        self.search_input.draw(f, Some(input_rect), emotes);
+        self.search_input.draw(f, Some(input_rect));
     }
 
     fn event(&mut self, event: &Event) -> Option<TerminalAction> {

--- a/src/ui/components/chat_input.rs
+++ b/src/ui/components/chat_input.rs
@@ -1,7 +1,6 @@
 use tui::{layout::Rect, Frame};
 
 use crate::{
-    emotes::Emotes,
     handlers::{
         config::SharedCompleteConfig,
         storage::SharedStorage,
@@ -95,8 +94,8 @@ impl ToString for ChatInputWidget {
 }
 
 impl Component for ChatInputWidget {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, emotes: Option<&mut Emotes>) {
-        self.input.draw(f, area, emotes);
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
+        self.input.draw(f, area);
     }
 
     fn event(&mut self, event: &Event) -> Option<TerminalAction> {

--- a/src/ui/components/dashboard.rs
+++ b/src/ui/components/dashboard.rs
@@ -9,7 +9,6 @@ use tui::{
 };
 
 use crate::{
-    emotes::Emotes,
     handlers::{
         config::SharedCompleteConfig,
         state::State,
@@ -158,7 +157,7 @@ impl DashboardWidget {
 }
 
 impl Component for DashboardWidget {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, emotes: Option<&mut Emotes>) {
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
         let r = area.map_or_else(|| f.size(), |a| a);
 
         let favorite_channels_len = {
@@ -218,9 +217,9 @@ impl Component for DashboardWidget {
         self.render_quit_selection_widget(f, &mut v_chunks);
 
         if self.channel_input.is_focused() {
-            self.channel_input.draw(f, None, emotes);
+            self.channel_input.draw(f, None);
         } else if self.following.is_focused() {
-            self.following.draw(f, None, None);
+            self.following.draw(f, None);
         }
     }
 

--- a/src/ui/components/debug.rs
+++ b/src/ui/components/debug.rs
@@ -8,7 +8,6 @@ use tui::{
 };
 
 use crate::{
-    emotes::Emotes,
     handlers::{
         config::{SharedCompleteConfig, ToVec},
         user_input::events::{Event, Key},
@@ -56,7 +55,7 @@ impl DebugWidget {
 }
 
 impl Component for DebugWidget {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, _emotes: Option<&mut Emotes>) {
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
         let r = area.map_or_else(|| f.size(), |a| a);
 
         let configs = self.get_config_values();

--- a/src/ui/components/error.rs
+++ b/src/ui/components/error.rs
@@ -6,7 +6,7 @@ use tui::{
     widgets::{block::Title, Block, Borders, Clear, Paragraph},
 };
 
-use crate::{emotes::Emotes, ui::components::Component};
+use crate::ui::components::Component;
 
 #[derive(Debug, Clone)]
 pub struct ErrorWidget {
@@ -32,7 +32,7 @@ impl ErrorWidget {
 }
 
 impl Component for ErrorWidget {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, _emotes: Option<&mut Emotes>) {
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
         let r = area.map_or_else(|| f.size(), |a| a);
 
         let paragraph = Paragraph::new(

--- a/src/ui/components/following.rs
+++ b/src/ui/components/following.rs
@@ -3,7 +3,6 @@ use once_cell::sync::Lazy;
 use tui::{layout::Rect, Frame};
 
 use crate::{
-    emotes::Emotes,
     handlers::{config::SharedCompleteConfig, user_input::events::Event},
     terminal::TerminalAction,
     twitch::{channels::Following, TwitchAction},
@@ -55,8 +54,8 @@ impl FollowingWidget {
 }
 
 impl Component for FollowingWidget {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, emotes: Option<&mut Emotes>) {
-        self.search_widget.draw(f, area, emotes);
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
+        self.search_widget.draw(f, area);
     }
 
     fn event(&mut self, event: &Event) -> Option<TerminalAction> {

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -6,7 +6,6 @@ use tui::{
 };
 
 use crate::{
-    emotes::Emotes,
     handlers::config::SharedCompleteConfig,
     ui::{
         components::Component,
@@ -31,7 +30,7 @@ impl HelpWidget {
 }
 
 impl Component for HelpWidget {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, _emotes: Option<&mut Emotes>) {
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
         let r = area.map_or_else(|| f.size(), |a| a);
 
         let mut rows = vec![];

--- a/src/ui/components/message_search.rs
+++ b/src/ui/components/message_search.rs
@@ -1,7 +1,6 @@
 use tui::{layout::Rect, Frame};
 
 use crate::{
-    emotes::Emotes,
     handlers::{
         config::SharedCompleteConfig,
         user_input::events::{Event, Key},
@@ -58,8 +57,8 @@ impl ToString for MessageSearchWidget {
 }
 
 impl Component for MessageSearchWidget {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, emotes: Option<&mut Emotes>) {
-        self.input.draw(f, area, emotes);
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
+        self.input.draw(f, area);
     }
 
     fn event(&mut self, event: &Event) -> Option<TerminalAction> {

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -26,7 +26,6 @@ use chrono::{DateTime, Local};
 use tui::{layout::Rect, Frame};
 
 use crate::{
-    emotes::Emotes,
     handlers::{
         app::SharedMessages,
         config::SharedCompleteConfig,
@@ -47,7 +46,7 @@ static WINDOW_SIZE_TOO_SMALL_ERROR: Lazy<Vec<&'static str>> = Lazy::new(|| {
 
 pub trait Component {
     #[allow(unused_variables)]
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, emotes: Option<&mut Emotes>) {
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
         todo!()
     }
 

--- a/src/ui/components/utils/input_widget.rs
+++ b/src/ui/components/utils/input_widget.rs
@@ -8,7 +8,6 @@ use tui::{
 };
 
 use crate::{
-    emotes::Emotes,
     handlers::{
         config::SharedCompleteConfig,
         storage::SharedStorage,
@@ -87,7 +86,7 @@ impl ToString for InputWidget {
 }
 
 impl Component for InputWidget {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, _emotes: Option<&mut Emotes>) {
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
         let r = area.map_or_else(|| centered_rect(60, 60, 20, f.size()), |a| a);
 
         let cursor_pos = get_cursor_position(&self.input);

--- a/src/ui/components/utils/search_widget.rs
+++ b/src/ui/components/utils/search_widget.rs
@@ -17,7 +17,6 @@ use tui::{
 };
 
 use crate::{
-    emotes::Emotes,
     handlers::{
         config::SharedCompleteConfig,
         user_input::events::{Event, Key},
@@ -147,11 +146,11 @@ where
     T: ToString + Clone,
     U: SearchItemGetter<T>,
 {
-    fn draw(&mut self, f: &mut Frame, area: Option<Rect>, emotes: Option<&mut Emotes>) {
+    fn draw(&mut self, f: &mut Frame, area: Option<Rect>) {
         let r = area.map_or_else(|| centered_rect(60, 60, 20, f.size()), |a| a);
 
         if self.error_widget.is_focused() {
-            self.error_widget.draw(f, Some(r), emotes);
+            self.error_widget.draw(f, Some(r));
 
             return;
         }
@@ -264,7 +263,7 @@ where
 
         let input_rect = Rect::new(rect.x, rect.bottom(), rect.width, 3);
 
-        self.search_input.draw(f, Some(input_rect), emotes);
+        self.search_input.draw(f, Some(input_rect));
     }
 
     fn event(&mut self, event: &Event) -> Option<TerminalAction> {

--- a/src/utils/pathing.rs
+++ b/src/utils/pathing.rs
@@ -1,4 +1,4 @@
-use color_eyre::{eyre::anyhow, Result};
+use anyhow::{anyhow, Result};
 use std::{
     env,
     fs::remove_file,

--- a/src/utils/pathing.rs
+++ b/src/utils/pathing.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use color_eyre::{eyre::anyhow, Result};
 use std::{
     env,
     fs::remove_file,

--- a/src/utils/styles.rs
+++ b/src/utils/styles.rs
@@ -4,6 +4,7 @@ use tui::style::{Color, Modifier, Style};
 pub const BORDER_NAME_DARK: Style = Style {
     fg: Some(Color::White),
     bg: None,
+    underline_color: None,
     add_modifier: Modifier::empty(),
     sub_modifier: Modifier::empty(),
 };
@@ -12,6 +13,7 @@ pub const BORDER_NAME_DARK: Style = Style {
 pub const BORDER_NAME_LIGHT: Style = Style {
     fg: Some(Color::Black),
     bg: None,
+    underline_color: None,
     add_modifier: Modifier::empty(),
     sub_modifier: Modifier::empty(),
 };
@@ -19,6 +21,7 @@ pub const BORDER_NAME_LIGHT: Style = Style {
 pub const DATETIME_DARK: Style = Style {
     fg: Some(Color::Rgb(173, 173, 184)),
     bg: None,
+    underline_color: None,
     add_modifier: Modifier::empty(),
     sub_modifier: Modifier::empty(),
 };
@@ -26,6 +29,7 @@ pub const DATETIME_DARK: Style = Style {
 pub const DATETIME_LIGHT: Style = Style {
     fg: Some(Color::Rgb(83, 83, 95)),
     bg: None,
+    underline_color: None,
     add_modifier: Modifier::empty(),
     sub_modifier: Modifier::empty(),
 };
@@ -33,12 +37,14 @@ pub const DATETIME_LIGHT: Style = Style {
 pub const HIGHLIGHT_NAME_DARK: Style = Style {
     fg: Some(Color::Black),
     bg: Some(Color::White),
+    underline_color: None,
     add_modifier: Modifier::BOLD,
     sub_modifier: Modifier::empty(),
 };
 pub const HIGHLIGHT_NAME_LIGHT: Style = Style {
     fg: Some(Color::White),
     bg: Some(Color::Black),
+    underline_color: None,
     add_modifier: Modifier::BOLD,
     sub_modifier: Modifier::empty(),
 };
@@ -46,6 +52,7 @@ pub const HIGHLIGHT_NAME_LIGHT: Style = Style {
 pub const COLUMN_TITLE: Style = Style {
     fg: Some(Color::LightCyan),
     bg: None,
+    underline_color: None,
     add_modifier: Modifier::BOLD,
     sub_modifier: Modifier::empty(),
 };
@@ -53,6 +60,7 @@ pub const COLUMN_TITLE: Style = Style {
 pub const SYSTEM_CHAT: Style = Style {
     fg: Some(Color::Red),
     bg: None,
+    underline_color: None,
     add_modifier: Modifier::BOLD,
     sub_modifier: Modifier::empty(),
 };
@@ -60,6 +68,7 @@ pub const SYSTEM_CHAT: Style = Style {
 pub const DASHBOARD_TITLE_COLOR: Style = Style {
     fg: Some(Color::Rgb(135, 120, 165)),
     bg: None,
+    underline_color: None,
     add_modifier: Modifier::empty(),
     sub_modifier: Modifier::empty(),
 };


### PR DESCRIPTION
This PR switches to using unicode placeholders to display emotes. 

Instead of having to track the emotes and then display them on top of spaces, we can directly display them using the `\u{10EEEE}` private unicode character. The emote will move automatically with the text. 
This should also allow emote display to work under tmux.

This feature is quite new and requires kitty v0.28, and is not yet implemented in wezterm. It also doesn't support emote overlays yet, I am working on a PR for kitty. This is why I'm making this a draft PR for now.

It simplifies the code a lot, but the emotes now need to be in a span alone, as the image id is encoded in the span color, and ratatui escapes the ansi codes. This is done in the modified `highlight` function in `data.rs`.
