### PR TITLE
Bump image-rs to 0.24.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.6"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
+checksum = "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -2101,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7449334f9ff2baf290d55d73983a7d6fa15e01198faef72af07e2a8db851e471"
+checksum = "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211"
 dependencies = [
  "flate2",
  "jpeg-decoder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ log = "0.4.19"
 fern = "0.6.2"
 dialoguer = { version = "0.10.4", default-features = false }
 reqwest = { version = "0.11.18", features = ["json"]}
-image = "0.24.6"
+image = "0.24.7"
 base64 = "0.21.2"
 tempfile = "3.7.0"
 anyhow = "1.0.72"

--- a/src/emotes/graphics_protocol.rs
+++ b/src/emotes/graphics_protocol.rs
@@ -5,7 +5,7 @@ use dialoguer::console::{Key, Term};
 use image::{
     codecs::{gif::GifDecoder, webp::WebPDecoder},
     io::Reader,
-    AnimationDecoder, ImageDecoder, ImageFormat,
+    AnimationDecoder, ImageDecoder, ImageFormat, Rgba,
 };
 use std::{
     env, fmt, fs,
@@ -204,13 +204,12 @@ impl Load {
         match image.format() {
             None => Err(anyhow!("Could not guess image format.")),
             Some(ImageFormat::WebP) => {
-                let decoder = WebPDecoder::new(image.into_inner())?;
+                let mut decoder = WebPDecoder::new(image.into_inner())?;
 
                 if decoder.has_animation() {
                     // Some animated webp images have a default white background color
                     // We replace it by a transparent background
-                    // TODO: uncomment this line once image-rs is updated from 0.24.6.
-                    // decoder.set_background_color(Rgba([0, 0, 0, 0]))?;
+                    decoder.set_background_color(Rgba([0, 0, 0, 0]))?;
                     Ok(Self::Animated(AnimatedImage::new(id, decoder)?))
                 } else {
                     let image = Reader::open(&path)?.with_guessed_format()?;


### PR DESCRIPTION
Upgrade image-rs to 0.24.7 which allows us to remove the white background in some wepb animated images.