### PR TITLE
Fix flake rustc version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1697456312,
@@ -16,9 +34,60 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1706487304,
+        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1709345349,
+        "narHash": "sha256-E2tsnkM97cGuzHKOqdkUXfmI+K1wS4dNTJJu5QH2Vuk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6e6fde31711e699be2e7fb67aae1c7e23ef606e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,32 @@
 {
   description = "Twitch chat in the terminal.";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
 
-  outputs = { self, nixpkgs }:
-  let
-    system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${system};
-    manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
-  in {
-    packages.${system}.default = pkgs.rustPlatform.buildRustPackage {
-      pname = manifest.name;
-      version = manifest.version;
+  outputs = { self, nixpkgs, rust-overlay }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      toolchain = rust-overlay.packages.${system}.rust.minimal;
+      manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+    in {
+      packages.${system}.default = (pkgs.makeRustPlatform {
+        cargo = toolchain;
+        rustc = toolchain;
+      }).buildRustPackage {
+        pname = manifest.name;
+        version = manifest.version;
 
-      buildInputs = [pkgs.openssl.dev];
-      nativeBuildInputs = [pkgs.pkg-config];
+        buildInputs = [ pkgs.openssl.dev ];
+        nativeBuildInputs = [ pkgs.pkg-config ];
 
-      src = pkgs.lib.cleanSource ./.;
-      cargoLock.lockFile = ./Cargo.lock;
+        src = pkgs.lib.cleanSource ./.;
+        cargoLock.lockFile = ./Cargo.lock;
+      };
+
+      apps.${system}.default = {
+        type = "app";
+        program = "${self.packages.${system}.default}/bin/twt";
+      };
     };
-
-    apps.${system}.default = {
-      type = "app";
-      program = "${self.packages.${system}.default}/bin/twt";
-    };
-  };
 }


### PR DESCRIPTION
rustc version in nixpkgs is 1.73.0 and clap requires rustc>=1.74.0
probably introduced by https://github.com/Xithrius/twitch-tui/commit/2cbb4b8f847494504c0f4e157921070d72dac3a8

added oxalica rust-overlay to get a more recent rustc version