### PR TITLE
Fix twitch animated emotes not detected

### DIFF
--- a/src/emotes/downloader.rs
+++ b/src/emotes/downloader.rs
@@ -30,6 +30,7 @@ mod twitch {
         id: String,
         name: String,
         images: Image,
+        format: Vec<String>,
     }
 
     #[derive(Deserialize)]
@@ -61,7 +62,18 @@ mod twitch {
         Ok(channel_emotes
             .into_iter()
             .chain(global_emotes)
-            .map(|emote| (emote.name, (emote.id, emote.images.url_1x, false)))
+            .map(|emote| {
+                let (id, url) = if emote.format.contains(&String::from("animated")) {
+                    (
+                        emote.id + "-animated",
+                        emote.images.url_1x.replace("/static/", "/animated/"),
+                    )
+                } else {
+                    (emote.id, emote.images.url_1x)
+                };
+
+                (emote.name, (id, url, false))
+            })
             .collect())
     }
 }


### PR DESCRIPTION
Twitch emotes are static by default, if an emote is animated, now downloads the animated version instead of the static one. This also renames the emote id to `id + '-animated'` so that the animated version still gets downloaded, even if the static one is already in the cache

Fixes #581 