### PR TITLE
Correctly handle twitch subscriber emotes

### DIFF
--- a/src/emotes/downloader.rs
+++ b/src/emotes/downloader.rs
@@ -1,13 +1,13 @@
 use color_eyre::Result;
 use futures::StreamExt;
-use reqwest::Client;
+use reqwest::{Client, Response};
 use std::{borrow::BorrowMut, collections::HashMap, path::Path};
 use tokio::io::AsyncWriteExt;
 
 use crate::{
     emotes::DownloadedEmotes,
     handlers::config::{CompleteConfig, FrontendConfig},
-    twitch::oauth::{get_channel_id, get_twitch_client},
+    twitch::oauth::{get_channel_id, get_twitch_client, get_twitch_client_id},
     utils::pathing::cache_path,
 };
 
@@ -38,18 +38,21 @@ mod twitch {
         data: Vec<Emote>,
     }
 
-    pub async fn get_emotes(client: &Client, channel_id: i32) -> Result<EmoteMap> {
-        let channel_emotes = client
-            .get(format!(
-                "https://api.twitch.tv/helix/chat/emotes?broadcaster_id={channel_id}",
-            ))
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<EmoteList>()
-            .await?
-            .data;
+    fn parse_emote_list(v: Vec<Emote>) -> EmoteMap {
+        v.into_iter()
+            .map(|emote| {
+                let url = if emote.format.contains(&String::from("animated")) {
+                    emote.images.url_1x.replace("/static/", "/animated/")
+                } else {
+                    emote.images.url_1x
+                };
 
+                (emote.name, (emote.id, url, false))
+            })
+            .collect()
+    }
+
+    pub async fn get_global_emotes(client: &Client) -> Result<EmoteMap> {
         let global_emotes = client
             .get("https://api.twitch.tv/helix/chat/emotes/global")
             .send()
@@ -59,22 +62,22 @@ mod twitch {
             .await?
             .data;
 
-        Ok(channel_emotes
-            .into_iter()
-            .chain(global_emotes)
-            .map(|emote| {
-                let (id, url) = if emote.format.contains(&String::from("animated")) {
-                    (
-                        emote.id + "-animated",
-                        emote.images.url_1x.replace("/static/", "/animated/"),
-                    )
-                } else {
-                    (emote.id, emote.images.url_1x)
-                };
+        Ok(parse_emote_list(global_emotes))
+    }
 
-                (emote.name, (id, url, false))
-            })
-            .collect())
+    pub async fn get_user_emotes(client: &Client, user_id: &str) -> Result<EmoteMap> {
+        let user_emotes = client
+            .get(format!(
+                "https://api.twitch.tv/helix/chat/emotes/user?user_id={user_id}",
+            ))
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<EmoteList>()
+            .await?
+            .data;
+
+        Ok(parse_emote_list(user_emotes))
     }
 }
 
@@ -313,6 +316,16 @@ mod frankerfacez {
     }
 }
 
+async fn save_emote(path: &Path, mut res: Response) -> Result<()> {
+    let mut file = tokio::fs::File::create(&path).await?;
+
+    while let Some(mut item) = res.chunk().await? {
+        file.write_all_buf(item.borrow_mut()).await?;
+    }
+
+    Ok(())
+}
+
 async fn download_emotes(emotes: EmoteMap) -> DownloadedEmotes {
     let client = &Client::new();
 
@@ -329,13 +342,9 @@ async fn download_emotes(emotes: EmoteMap) -> DownloadedEmotes {
                     return Ok((x, (filename, o)));
                 }
 
-                let mut res = client.get(&url).send().await?.error_for_status()?;
+                let res = client.get(&url).send().await?.error_for_status()?;
 
-                let mut file = tokio::fs::File::create(&path).await?;
-
-                while let Some(mut item) = res.chunk().await? {
-                    file.write_all_buf(item.borrow_mut()).await?;
-                }
+                save_emote(path, res).await?;
 
                 Ok((x, (filename, o)))
             }),
@@ -348,6 +357,7 @@ async fn download_emotes(emotes: EmoteMap) -> DownloadedEmotes {
     .collect()
 }
 
+#[derive(Eq, PartialEq)]
 enum EmoteProvider {
     Twitch,
     BetterTTV,
@@ -374,21 +384,33 @@ fn get_enabled_emote_providers(config: &FrontendConfig) -> Vec<EmoteProvider> {
     providers
 }
 
-pub async fn get_emotes(config: &CompleteConfig, channel: &str) -> Result<DownloadedEmotes> {
+pub async fn get_emotes(
+    config: &CompleteConfig,
+    channel: &str,
+) -> Result<(DownloadedEmotes, DownloadedEmotes)> {
     // Reuse the same client and headers for twitch requests
     let twitch_client = get_twitch_client(config.twitch.token.as_deref()).await?;
+    let user_id = &get_twitch_client_id(None).await?.user_id;
 
     let channel_id = get_channel_id(&twitch_client, channel).await?;
 
     let enabled_emotes = get_enabled_emote_providers(&config.frontend);
 
-    let twitch_get_emotes = |c: i32| twitch::get_emotes(&twitch_client, c);
+    let user_emotes = if enabled_emotes.contains(&EmoteProvider::Twitch) {
+        twitch::get_user_emotes(&twitch_client, user_id)
+            .await
+            .unwrap_or_default()
+    } else {
+        HashMap::default()
+    };
+
+    let twitch_get_global_emotes = || twitch::get_global_emotes(&twitch_client);
 
     // Concurrently get the list of emotes for each provider
-    let emotes =
+    let global_emotes =
         futures::stream::iter(enabled_emotes.into_iter().map(|emote_provider| async move {
             match emote_provider {
-                EmoteProvider::Twitch => twitch_get_emotes(channel_id).await,
+                EmoteProvider::Twitch => twitch_get_global_emotes().await,
                 EmoteProvider::BetterTTV => betterttv::get_emotes(channel_id).await,
                 EmoteProvider::SevenTV => seventv::get_emotes(channel_id).await,
                 EmoteProvider::FrankerFaceZ => frankerfacez::get_emotes(channel_id).await,
@@ -402,5 +424,35 @@ pub async fn get_emotes(config: &CompleteConfig, channel: &str) -> Result<Downlo
         .flatten()
         .collect::<EmoteMap>();
 
-    Ok(download_emotes(emotes).await)
+    Ok((
+        download_emotes(user_emotes).await,
+        download_emotes(global_emotes).await,
+    ))
+}
+
+pub async fn get_twitch_emote(name: &str) -> Result<()> {
+    // Checks if emote is already downloaded.
+    let path = cache_path(name);
+    let path = Path::new(&path);
+
+    if tokio::fs::metadata(&path).await.is_ok() {
+        return Ok(());
+    }
+
+    // Download it if it is not in the cache, try the animated version first.
+    let url = format!("https://static-cdn.jtvnw.net/emoticons/v2/{name}/animated/light/1.0");
+    let client = Client::new();
+    let res = client.get(&url).send().await?.error_for_status();
+
+    let res = if res.is_err() {
+        client
+            .get(&url.replace("animated", "static"))
+            .send()
+            .await?
+            .error_for_status()
+    } else {
+        res
+    }?;
+
+    save_emote(path, res).await
 }

--- a/src/emotes/downloader.rs
+++ b/src/emotes/downloader.rs
@@ -376,7 +376,7 @@ fn get_enabled_emote_providers(config: &FrontendConfig) -> Vec<EmoteProvider> {
 
 pub async fn get_emotes(config: &CompleteConfig, channel: &str) -> Result<DownloadedEmotes> {
     // Reuse the same client and headers for twitch requests
-    let twitch_client = get_twitch_client(config.twitch.token.clone()).await?;
+    let twitch_client = get_twitch_client(config.twitch.token.as_deref()).await?;
 
     let channel_id = get_channel_id(&twitch_client, channel).await?;
 

--- a/src/twitch/channels.rs
+++ b/src/twitch/channels.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use crate::{handlers::config::TwitchConfig, ui::components::utils::SearchItemGetter};
 
-use super::oauth::{get_channel_id, get_twitch_client};
+use super::oauth::{get_twitch_client, get_twitch_client_id};
 
 const FOLLOWER_COUNT: usize = 100;
 
@@ -53,7 +53,7 @@ pub struct Following {
 }
 
 // https://dev.twitch.tv/docs/api/reference/#get-followed-channels
-pub async fn get_user_following(client: &Client, user_id: i32) -> Result<FollowingList> {
+pub async fn get_user_following(client: &Client, user_id: &str) -> Result<FollowingList> {
     Ok(client
         .get(format!(
             "https://api.twitch.tv/helix/channels/followed?user_id={user_id}&first={FOLLOWER_COUNT}",
@@ -66,12 +66,8 @@ pub async fn get_user_following(client: &Client, user_id: i32) -> Result<Followi
 }
 
 pub async fn get_following(twitch_config: &TwitchConfig) -> Result<FollowingList> {
-    let oauth_token = twitch_config.token.clone();
-    let app_user = twitch_config.username.clone();
-
-    let client = get_twitch_client(oauth_token).await.unwrap();
-
-    let user_id = get_channel_id(&client, &app_user).await.unwrap();
+    let client = get_twitch_client(twitch_config.token.as_deref()).await?;
+    let user_id = &get_twitch_client_id(None).await?.user_id;
 
     get_user_following(&client, user_id).await
 }

--- a/src/twitch/oauth.rs
+++ b/src/twitch/oauth.rs
@@ -4,18 +4,30 @@ use reqwest::{
     Client,
 };
 use serde::Deserialize;
+use std::sync::OnceLock;
 
 #[derive(Deserialize)]
 #[allow(dead_code)]
 pub struct ClientId {
-    client_id: String,
-    login: String,
-    scopes: Vec<String>,
-    user_id: String,
-    expires_in: i32,
+    pub client_id: String,
+    pub login: String,
+    pub scopes: Vec<String>,
+    pub user_id: String,
+    pub expires_in: i32,
 }
 
-pub async fn get_twitch_client_id(token: &str) -> Result<String> {
+pub async fn get_twitch_client_id(token: Option<&str>) -> Result<&ClientId> {
+    static TWITCH_CLIENT_ID: OnceLock<ClientId> = OnceLock::new();
+
+    if let Some(id) = TWITCH_CLIENT_ID.get() {
+        return Ok(id);
+    }
+
+    let token = token.context("Twitch token is empty")?;
+
+    // Strips the `oauth:` prefix if it exists
+    let token = token.strip_prefix("oauth:").unwrap_or(token);
+
     let client = Client::new();
 
     let data = client
@@ -26,26 +38,25 @@ pub async fn get_twitch_client_id(token: &str) -> Result<String> {
         .error_for_status()
         .unwrap();
 
-    let text = data.json::<ClientId>().await?;
+    let client_id = data.json::<ClientId>().await?;
 
-    Ok(text.client_id)
+    Ok(TWITCH_CLIENT_ID.get_or_init(|| client_id))
 }
 
-pub async fn get_twitch_client(oauth_token: Option<String>) -> Result<Client> {
+pub async fn get_twitch_client(oauth_token: Option<&str>) -> Result<Client> {
     let token = oauth_token
-        .as_ref()
         .context("Twitch token is empty")?
         .strip_prefix("oauth:")
         .context("token does not start with `oauth:`")?;
 
-    let client_id = get_twitch_client_id(token).await?;
+    let client_id = &get_twitch_client_id(Some(token)).await?.client_id;
 
     let mut headers = HeaderMap::new();
     headers.insert(
         AUTHORIZATION,
         HeaderValue::from_str(&format!("Bearer {token}"))?,
     );
-    headers.insert("Client-Id", HeaderValue::from_str(&client_id)?);
+    headers.insert("Client-Id", HeaderValue::from_str(client_id)?);
 
     Ok(Client::builder().default_headers(headers).build()?)
 }


### PR DESCRIPTION
This PR switches to parsing the emotes irc tag to find twitch emotes to display, to actually correctly display emotes from people that are subbed to a channel.
Users subscribed to a channel can use emotes from this channel into other channels chat, this enables detection of such emotes.

There's still a bit of work to do to detect emotes that the current user can use, to display them in the emote picker, and I need to clean up the code and do some tests, so this is why this is a draft PR.

This also reverts the change that added the '-animated' string at the end of animated twitch emotes (#587), as I found it complicates stuff a bit. (ie. I would need to check the cache for both the animated and normal version if they had different name). The only issue is that users would need to delete the cache to switch to the animated version of the twitch emotes, if they had the static one already in cache.
If you would prefer to not need user intervention, I can try to think of a way to avoid this, but clearing the cache is definitely the easier option.