### PR TITLE
fix: ignored TWT_TOKEN env variable

### DIFF
--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -498,8 +498,7 @@ impl CompleteConfig {
 
             merge_args_into_config(&mut config, cli);
 
-            let token: Option<&'static str> = option_env!("TWT_TOKEN");
-
+            let token = env::var("TWT_TOKEN").ok();
             if let Some(env_token) = token {
                 if !env_token.is_empty() {
                     config.twitch.token = Some(env_token.to_string());


### PR DESCRIPTION
Hi !

Discovered this tool yesterday. I wondered why I can't pass TWT_TOKEN env variable to the CLI. It seems the variable is ignored. 

I made this fix. It should deserve a test, but I don't know Rust so much. 
