### PR TITLE
Fix clippy lints introduced with rust 1.78

### DIFF
--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -126,7 +126,7 @@ pub struct FrontendConfig {
     pub betterttv_emotes: bool,
     /// If 7tv emotes should be displayed (requires kitty terminal).
     pub seventv_emotes: bool,
-    /// If FrankerFacez emotes should be displayed (requires kitty terminal).
+    /// If frankerfacez emotes should be displayed (requires kitty terminal).
     pub frankerfacez_emotes: bool,
     /// Channels to always be displayed in the start screen.
     pub favorite_channels: Vec<String>,

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::{Eq, PartialEq},
+    fmt::Display,
     str::FromStr,
 };
 
@@ -13,13 +14,16 @@ pub enum NormalMode {
     Search,
 }
 
-impl ToString for NormalMode {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Insert => "insert",
-            Self::Search => "search",
-        }
-        .to_string()
+impl Display for NormalMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Insert => "insert",
+                Self::Search => "search",
+            }
+        )
     }
 }
 
@@ -48,14 +52,17 @@ impl Default for State {
     }
 }
 
-impl ToString for State {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Dashboard => "dashboard",
-            Self::Normal => "normal",
-            Self::Help => "help",
-        }
-        .to_string()
+impl Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Dashboard => "dashboard",
+                Self::Normal => "normal",
+                Self::Help => "help",
+            }
+        )
     }
 }
 

--- a/src/handlers/storage.rs
+++ b/src/handlers/storage.rs
@@ -78,7 +78,7 @@ impl Storage {
 
     pub fn add(&mut self, key: &str, value: String) {
         if ITEM_KEYS.contains(&key) {
-            if let Some(item) = self.items.get_mut(&key.to_string()) {
+            if let Some(item) = self.items.get_mut(key) {
                 if item.enabled {
                     if let Some(position) = item.content.iter().position(|x| x == &value) {
                         item.content.remove(position);
@@ -94,7 +94,7 @@ impl Storage {
     pub fn get(&self, key: &str) -> Vec<String> {
         if ITEM_KEYS.contains(&key) {
             self.items
-                .get(&key.to_string())
+                .get(key)
                 .map_or_else(Vec::new, |item| item.content.clone())
         } else {
             panic!("Attempted to get key {key} from JSON storage.");
@@ -123,7 +123,7 @@ impl Storage {
 
     pub fn remove_inner_with(&mut self, key: &str, value: &str) -> String {
         if ITEM_KEYS.contains(&key) {
-            let item = self.items.get_mut(&key.to_string()).unwrap();
+            let item = self.items.get_mut(key).unwrap();
 
             if let Some(position) = item.content.iter().position(|x| x == value) {
                 item.content.remove(position)

--- a/src/handlers/user_input/events.rs
+++ b/src/handlers/user_input/events.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{fmt::Display, time::Duration};
 
 use crossterm::event::{
     self, Event as CEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEventKind,
@@ -30,13 +30,16 @@ pub enum Key {
     ScrollDown,
 }
 
-impl ToString for Key {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Char(c) | Self::Ctrl(c) | Self::Alt(c) => c,
-            _ => unimplemented!(),
-        }
-        .to_string()
+impl Display for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Char(c) | Self::Ctrl(c) | Self::Alt(c) => c,
+                _ => unimplemented!(),
+            }
+        )
     }
 }
 

--- a/src/twitch/channels.rs
+++ b/src/twitch/channels.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Display,
     string::{String, ToString},
     vec::Vec,
 };
@@ -22,9 +23,9 @@ pub struct FollowingUser {
     followed_at: String,
 }
 
-impl ToString for FollowingUser {
-    fn to_string(&self) -> String {
-        self.broadcaster_login.to_string()
+impl Display for FollowingUser {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.broadcaster_login)
     }
 }
 

--- a/src/ui/components/channel_switcher.rs
+++ b/src/ui/components/channel_switcher.rs
@@ -1,6 +1,7 @@
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::fmt::Display;
 use tui::{
     layout::Rect,
     prelude::{Alignment, Margin},
@@ -133,9 +134,9 @@ impl ChannelSwitcherWidget {
     }
 }
 
-impl ToString for ChannelSwitcherWidget {
-    fn to_string(&self) -> String {
-        self.search_input.to_string()
+impl Display for ChannelSwitcherWidget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.search_input)
     }
 }
 
@@ -310,8 +311,11 @@ impl Component for ChannelSwitcherWidget {
 
                                     self.search_input.update("");
 
-                                    self.config.borrow_mut().twitch.channel =
-                                        selected_channel.clone();
+                                    self.config
+                                        .borrow_mut()
+                                        .twitch
+                                        .channel
+                                        .clone_from(&selected_channel);
 
                                     return Some(TerminalAction::Enter(TwitchAction::Join(
                                         selected_channel,
@@ -332,7 +336,11 @@ impl Component for ChannelSwitcherWidget {
 
                         self.search_input.update("");
 
-                        self.config.borrow_mut().twitch.channel = selected_channel.clone();
+                        self.config
+                            .borrow_mut()
+                            .twitch
+                            .channel
+                            .clone_from(selected_channel);
 
                         return Some(TerminalAction::Enter(TwitchAction::Join(
                             selected_channel.to_string(),
@@ -351,7 +359,11 @@ impl Component for ChannelSwitcherWidget {
 
                         self.search_input.update("");
 
-                        self.config.borrow_mut().twitch.channel = selected_channel.clone();
+                        self.config
+                            .borrow_mut()
+                            .twitch
+                            .channel
+                            .clone_from(&selected_channel);
 
                         return Some(TerminalAction::Enter(TwitchAction::Join(selected_channel)));
                     }

--- a/src/ui/components/chat_input.rs
+++ b/src/ui/components/chat_input.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use tui::{layout::Rect, Frame};
 
 use crate::{
@@ -92,9 +93,9 @@ impl ChatInputWidget {
     }
 }
 
-impl ToString for ChatInputWidget {
-    fn to_string(&self) -> String {
-        self.input.to_string()
+impl Display for ChatInputWidget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.input)
     }
 }
 

--- a/src/ui/components/following.rs
+++ b/src/ui/components/following.rs
@@ -62,7 +62,7 @@ impl Component for FollowingWidget {
         let action = self.search_widget.event(event).await;
 
         if let Some(TerminalAction::Enter(TwitchAction::Join(channel))) = &action {
-            self.config.borrow_mut().twitch.channel = channel.clone();
+            self.config.borrow_mut().twitch.channel.clone_from(channel);
         }
 
         action

--- a/src/ui/components/message_search.rs
+++ b/src/ui/components/message_search.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use tui::{layout::Rect, Frame};
 
 use crate::{
@@ -50,9 +51,9 @@ impl MessageSearchWidget {
     }
 }
 
-impl ToString for MessageSearchWidget {
-    fn to_string(&self) -> String {
-        self.input.to_string()
+impl Display for MessageSearchWidget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.input)
     }
 }
 

--- a/src/ui/components/utils/input_widget.rs
+++ b/src/ui/components/utils/input_widget.rs
@@ -1,4 +1,5 @@
 use rustyline::{line_buffer::LineBuffer, At, Word};
+use std::fmt::Display;
 use tui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -91,9 +92,9 @@ impl<T: Clone> InputWidget<T> {
     }
 }
 
-impl<T: Clone> ToString for InputWidget<T> {
-    fn to_string(&self) -> String {
-        self.input.to_string()
+impl<T: Clone> Display for InputWidget<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.input.as_str())
     }
 }
 


### PR DESCRIPTION
This should fix all new clippy warnings that were introduced with rust 1.78. 
Most of them were fixed by replacing `ToString` implementations with `Display`.