### PR TITLE
Change oauth config prefix in docs from `:oauth` to `oauth:`

### DIFF
--- a/book/src/guide/configuration.md
+++ b/book/src/guide/configuration.md
@@ -20,7 +20,7 @@ The latter is needed for emotes and what users you follow. If you want those fea
 
 The minimal scope generator will only give you scopes of `chat:read`, `chat:edit`, `whispers:read`, `whispers:edit`, and `channel:moderate`. Be aware that whispers are currently not supported.
 
-Once you have your token, put `:oauth` at the start if it's not there already, then place it in one of two places:
+Once you have your token, put `oauth:` at the start if it's not there already, then place it in one of two places:
 
 1. The `token` variable in the `config.toml` that was previously generated.
 2. The environment variable `TWT_TOKEN`.


### PR DESCRIPTION
This got me a bit confused during setup, updated it to match the `twitch/oauth.rs` code.  😅

https://github.com/Xithrius/twitch-tui/blob/main/src/twitch/oauth.rs#L29