### PR TITLE
Fix off by one error in highlight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,14 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3039,6 +3040,26 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -395,9 +395,10 @@ impl MessageData {
     ) -> Vec<Span<'s>> {
         static EMOTE_FINDER: Lazy<memmem::Finder> =
             Lazy::new(|| memmem::Finder::new(ZERO_WIDTH_SPACE_STR));
+        let line_is_empty = line.is_empty();
 
         // A line contains emotes if `emotes` is not empty and `line` starts with a unicode placeholder or contains ZWS.
-        if emotes.is_empty()
+        let spans = if emotes.is_empty()
             || (!line.starts_with(PRIVATE_USE_UNICODE)
                 && EMOTE_FINDER.find(line.as_bytes()).is_none())
         {
@@ -436,7 +437,9 @@ impl MessageData {
 
             *start_index = start_index.saturating_sub(ZERO_WIDTH_SPACE_STR.len());
             spans
-        }
+        };
+        *start_index += usize::from(!line_is_empty);
+        spans
     }
 
     pub fn to_vec(
@@ -846,7 +849,7 @@ mod tests {
 
         assert_eq!(emotes, EMOTES_ID_PID);
 
-        assert_eq!(start_index, line.len());
+        assert_eq!(start_index - 1, line.len());
 
         assert_eq!(
             spans,
@@ -899,7 +902,7 @@ mod tests {
         );
 
         assert!(emotes.is_empty());
-        assert_eq!(start_index, line.len());
+        assert_eq!(start_index - 1, line.len());
 
         assert_eq!(
             spans,


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/7f6b13dc-d73e-465a-964c-896702b930ae)

after
![image](https://github.com/user-attachments/assets/95f9a894-6311-4469-b2f3-79431d25275a)

it does not account for the newlines properly

shoutout to [mostlymaxi's](https://github.com/mostlymaxi) chat for noticing this
