### PR TITLE
Fix off by one error in hightlight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,13 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -3040,26 +3039,6 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -395,10 +395,9 @@ impl MessageData {
     ) -> Vec<Span<'s>> {
         static EMOTE_FINDER: Lazy<memmem::Finder> =
             Lazy::new(|| memmem::Finder::new(ZERO_WIDTH_SPACE_STR));
-        let line_is_empty = line.is_empty();
 
         // A line contains emotes if `emotes` is not empty and `line` starts with a unicode placeholder or contains ZWS.
-        let spans = if emotes.is_empty()
+        if emotes.is_empty()
             || (!line.starts_with(PRIVATE_USE_UNICODE)
                 && EMOTE_FINDER.find(line.as_bytes()).is_none())
         {
@@ -437,9 +436,7 @@ impl MessageData {
 
             *start_index = start_index.saturating_sub(ZERO_WIDTH_SPACE_STR.len());
             spans
-        };
-        *start_index += usize::from(!line_is_empty);
-        spans
+        }
     }
 
     pub fn to_vec(
@@ -849,7 +846,7 @@ mod tests {
 
         assert_eq!(emotes, EMOTES_ID_PID);
 
-        assert_eq!(start_index - 1, line.len());
+        assert_eq!(start_index, line.len());
 
         assert_eq!(
             spans,
@@ -902,7 +899,7 @@ mod tests {
         );
 
         assert!(emotes.is_empty());
-        assert_eq!(start_index - 1, line.len());
+        assert_eq!(start_index, line.len());
 
         assert_eq!(
             spans,


### PR DESCRIPTION
It's a quick fix but should work. 
I don't know if it would be more efficient to maybe get the highlights indices after wrapping the message, which is the core of the issue here.
edit: I just realized it would break highlight of words spanning multiple lines so I'm not sure what a better solution would look like.

I couldn't manage to find how to send a message with newlines either with the twitch website or with twt so I just added a test case for it, but maybe @vesdev can confirm this fixes it?

Oh and I reverted the PR completely, which downgrades ahash, let me know if  you want me to update it back.