### PR TITLE
remove config storage.channels check for autofill

### DIFF
--- a/src/ui/components/utils/input_widget.rs
+++ b/src/ui/components/utils/input_widget.rs
@@ -140,16 +140,9 @@ impl<T: Clone> Component for InputWidget<T> {
         };
 
         self.suggestion = self
-            .config
-            .borrow()
-            .storage
-            .channels
-            .then(|| {
-                self.input_suggester
-                    .as_ref()
-                    .and_then(|(items, suggester)| suggester(items.clone(), self.input.to_string()))
-            })
-            .flatten();
+            .input_suggester
+            .as_ref()
+            .and_then(|(items, suggester)| suggester(items.clone(), self.input.to_string()));
 
         let block = Block::default()
             .borders(Borders::ALL)
@@ -265,14 +258,9 @@ impl<T: Clone> Component for InputWidget<T> {
                     self.input.backspace(1, &mut self.input_listener);
                 }
                 Key::Tab => {
-                    if self.config.borrow().storage.channels {
-                        if let Some(suggestion) = &self.suggestion {
-                            self.input.update(
-                                suggestion,
-                                suggestion.len(),
-                                &mut self.input_listener,
-                            );
-                        }
+                    if let Some(suggestion) = &self.suggestion {
+                        self.input
+                            .update(suggestion, suggestion.len(), &mut self.input_listener);
                     }
                 }
                 Key::Ctrl('p') => panic!("Manual panic triggered by user."),


### PR DESCRIPTION
currently, the InputWidget suggestion setting and tab autofilling implementation depends on storage.channels being set to true, (i assume because it was mainly used for the channel switcher then), so its currently unable to autofill emotes/commands/mentions if it is not set as such. i believe just removing the checks shouldnt change anything for any of the uses of InputWidget, as at least from my knowledge, the channel switcher wont add entries unless that config option is set, but maybe im wrong im not sure :3c,