### PR TITLE
Custom keybinds

### DIFF
--- a/default-config.toml
+++ b/default-config.toml
@@ -99,3 +99,115 @@ right_align_usernames = false
 show_unsupported_screen_size = true
 # The following widget will only contain channels that are currently live
 only_get_live_followed_channels = false
+
+[keybinds]
+# Open the debug window
+toggle_debug_focus = ["Ctrl+d"]
+
+[keybinds.dashboard]
+# Join the selected channel
+join = ["Enter"]
+# Open the recent channel search popup
+recent_channels_search = ["s"]
+# Open the followed channel search popup
+followed_channels_search = ["f"]
+# Have the keybinds popup window appear
+help = ["?", "h"]
+# Quit the application
+quit = ["q"]
+# Manually crash the application
+crash_application = ["Ctrl+p"]
+
+[keybinds.normal]
+# Enter message (chat) mode for sending messages
+enter_insert = ["i", "c"]
+# Messaging mode with mention symbol
+enter_insert_with_mention = ["@"]
+# Messaging mode with command symbol
+enter_insert_with_command = ["/"]
+# Go to the dashboard screen (start screen)
+enter_dashboard = ["S"]
+# Search messages
+search_messages = ["Ctrl+f"]
+# Toggle the message filter
+toggle_message_filter = ["Ctrl+t"]
+# Reverse the message filter
+reverse_message_filter = ["Ctrl+r"]
+# Go back to the previous window
+back_to_previous_window = ["Esc"]
+# Scroll chat down
+scroll_down = ["ScrollDown", "Down", "j"]
+# Scroll chat up
+scroll_up = ["ScrollUp", "Up", "k"]
+# Scroll chat to top
+scroll_to_end = ["G"]
+# Scroll chat to bottom
+scroll_to_start = ["g"]
+# Open current stream in browser
+open_in_browser = ["o"]
+# Open the recent channel search widget
+recent_channels_search = ["s"]
+# Open the followed channel search widget
+followed_channels_search = ["f"]
+# Have the keybinds popup window appear
+help = ["?", "h"]
+# Quit the application
+quit = ["q"]
+# Manually crash the application
+crash_application = ["Ctrl+p"]
+
+[keybinds.insert]
+# Fill in suggestion, if available
+fill_suggestion = ["Tab"]
+# Confirm the input text to go through
+confirm_text_input = ["Enter"]
+# Go back to the previous window
+back_to_previous_window = ["Esc"]
+# Move cursor to the right
+move_cursor_right = ["Right", "Ctrl+f"]
+# Move cursor to the left
+move_cursor_left = ["Left", "Ctrl+b"]
+# Move cursor to the start
+move_cursor_start = ["Home", "Ctrl+a"]
+# Move cursor to the end
+move_cursor_end = ["End", "Ctrl+e"]
+# Swap previous item with current item
+swap_previous_item_with_current = ["Ctrl+t"]
+# Remove everything after the cursor
+remove_after_cursor = ["Ctrl+k"]
+# Remove everything before the cursor
+remove_before_cursor = ["Ctrl+u"]
+# Remove the previous word
+remove_previous_word = ["Ctrl+w"]
+# Remove item to the right
+remove_item_to_right = ["Delete", "Ctrl+d"]
+# Toggle the filter
+toggle_message_filter = ["Ctrl+t"]
+# Reverse the filter
+reverse_message_filter = ["Ctrl+r"]
+# Move to the end of the next word
+end_of_next_word = ["Alt+f"]
+# Move to the start of the previous word
+start_of_previous_word = ["Alt+b"]
+# Swap previous word with current word
+swap_previous_word_with_current = ["Alt+t"]
+# Toggle emote picker
+toggle_emote_picker = ["Ctrl+e"]
+# Quit the application
+quit = ["Ctrl+q"]
+# Manually crash the application
+crash_application = ["Ctrl+p"]
+
+[keybinds.selection]
+# Move selection to next item
+next_item = ["ScrollDown", "Down"]
+# Move selection to previous item
+prev_item = ["ScrollUp", "Up"]
+# Delete the currently selected item
+delete_item = ["Ctrl+d"]
+# Confirm the currently selected item
+select = ["Enter"]
+# Go back to the previous window
+back_to_previous_window = ["Esc"]
+# Manually crash the application
+crash_application = ["Ctrl+p"]

--- a/default-config.toml
+++ b/default-config.toml
@@ -192,7 +192,7 @@ start_of_previous_word = ["Alt+b"]
 # Swap previous word with current word
 swap_previous_word_with_current = ["Alt+t"]
 # Toggle emote picker
-toggle_emote_picker = ["Ctrl+e"]
+toggle_emote_picker = ["Alt+e"]
 # Quit the application
 quit = ["Ctrl+q"]
 # Manually crash the application

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -354,7 +354,7 @@ impl Default for InsertKeybindsConfig {
             end_of_next_word: vec![Key::Alt('f')],
             start_of_previous_word: vec![Key::Alt('b')],
             swap_previous_word_with_current: vec![Key::Alt('t')],
-            toggle_emote_picker: vec![Key::Ctrl('e')],
+            toggle_emote_picker: vec![Key::Alt('e')],
             quit: vec![Key::Ctrl('q')],
             crash_application: vec![Key::Ctrl('p')],
         }

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -368,7 +368,7 @@ impl Default for SelectionKeybindsConfig {
             select: vec![Key::Enter],
             delete_entry: vec![Key::Ctrl('d')],
             back_to_previous_window: vec![Key::Esc],
-            crash_application: vec![Key::Enter],
+            crash_application: vec![Key::Ctrl('p')],
         }
     }
 }

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -225,6 +225,7 @@ pub struct SelectionKeybindsConfig {
     pub delete_item: Vec<Key>,
     pub select: Vec<Key>,
     pub back_to_previous_window: Vec<Key>,
+    pub quit: Vec<Key>,
     pub crash_application: Vec<Key>,
 }
 
@@ -300,10 +301,10 @@ impl Default for DashboardKeybindsConfig {
     fn default() -> Self {
         Self {
             join: vec![Key::Enter],
-            help: vec![Key::Char('?'), Key::Char('h')],
-            quit: vec![Key::Char('q')],
             recent_channels_search: vec![Key::Char('s')],
             followed_channels_search: vec![Key::Char('f')],
+            help: vec![Key::Char('?'), Key::Char('h')],
+            quit: vec![Key::Char('q')],
             crash_application: vec![Key::Ctrl('p')],
         }
     }
@@ -324,10 +325,10 @@ impl Default for NormalKeybindsConfig {
             scroll_to_end: vec![Key::Char('G')],
             scroll_to_start: vec![Key::Char('g')],
             open_in_browser: vec![Key::Char('o')],
-            help: vec![Key::Char('?'), Key::Char('h')],
-            quit: vec![Key::Char('q')],
             recent_channels_search: vec![Key::Char('s')],
             followed_channels_search: vec![Key::Char('f')],
+            help: vec![Key::Char('?'), Key::Char('h')],
+            quit: vec![Key::Char('q')],
             crash_application: vec![Key::Ctrl('p')],
         }
     }
@@ -368,6 +369,7 @@ impl Default for SelectionKeybindsConfig {
             select: vec![Key::Enter],
             delete_item: vec![Key::Ctrl('d')],
             back_to_previous_window: vec![Key::Esc],
+            quit: vec![Key::Char('q')],
             crash_application: vec![Key::Ctrl('p')],
         }
     }

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -162,10 +162,10 @@ pub struct KeybindsConfig {
 #[serde(default)]
 pub struct DashboardKeybindsConfig {
     pub join: Vec<Key>,
-    pub help: Vec<Key>,
-    pub quit: Vec<Key>,
     pub recent_channels_search: Vec<Key>,
     pub followed_channels_search: Vec<Key>,
+    pub help: Vec<Key>,
+    pub quit: Vec<Key>,
     pub crash_application: Vec<Key>,
 }
 
@@ -185,10 +185,10 @@ pub struct NormalKeybindsConfig {
     pub scroll_to_end: Vec<Key>,
     pub scroll_to_start: Vec<Key>,
     pub open_in_browser: Vec<Key>,
-    pub help: Vec<Key>,
-    pub quit: Vec<Key>,
     pub recent_channels_search: Vec<Key>,
     pub followed_channels_search: Vec<Key>,
+    pub help: Vec<Key>,
+    pub quit: Vec<Key>,
     pub crash_application: Vec<Key>,
 }
 
@@ -220,9 +220,9 @@ pub struct InsertKeybindsConfig {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct SelectionKeybindsConfig {
-    pub scroll_down: Vec<Key>,
-    pub scroll_up: Vec<Key>,
-    pub delete_entry: Vec<Key>,
+    pub next_item: Vec<Key>,
+    pub prev_item: Vec<Key>,
+    pub delete_item: Vec<Key>,
     pub select: Vec<Key>,
     pub back_to_previous_window: Vec<Key>,
     pub crash_application: Vec<Key>,
@@ -363,10 +363,10 @@ impl Default for InsertKeybindsConfig {
 impl Default for SelectionKeybindsConfig {
     fn default() -> Self {
         Self {
-            scroll_up: vec![Key::ScrollUp, Key::Up],
-            scroll_down: vec![Key::ScrollDown, Key::Down],
+            prev_item: vec![Key::ScrollUp, Key::Up],
+            next_item: vec![Key::ScrollDown, Key::Down],
             select: vec![Key::Enter],
-            delete_entry: vec![Key::Ctrl('d')],
+            delete_item: vec![Key::Ctrl('d')],
             back_to_previous_window: vec![Key::Esc],
             crash_application: vec![Key::Ctrl('p')],
         }

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -6,6 +6,7 @@ use std::{
     path::Path,
     rc::Rc,
     str::FromStr,
+    vec,
 };
 
 use color_eyre::eyre::{Error, Result, bail};
@@ -20,6 +21,7 @@ use crate::{
         args::{Cli, merge_args_into_config},
         interactive::interactive_config,
         state::State,
+        user_input::events::Key,
     },
     utils::pathing::{cache_path, config_path},
 };
@@ -39,6 +41,8 @@ pub struct CoreConfig {
     pub filters: FiltersConfig,
     /// How everything looks to the user.
     pub frontend: FrontendConfig,
+
+    pub keybinds: KeybindsConfig,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -144,6 +148,67 @@ pub struct FrontendConfig {
     pub only_get_live_followed_channels: bool,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct KeybindsConfig {
+    pub dashboard: DashboardKeybindsConfig,
+    pub normal: NormalKeybindsConfig,
+    pub insert: InsertKeybindsConfig,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
+pub struct DashboardKeybindsConfig {
+    join: Vec<Key>,
+    help: Vec<Key>,
+    quit: Vec<Key>,
+    recent_channels_search: Vec<Key>,
+    followed_channels_search: Vec<Key>,
+    crash_application: Vec<Key>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
+pub struct NormalKeybindsConfig {
+    enter_insert: Vec<Key>,
+    enter_insert_with_mention: Vec<Key>,
+    enter_insert_with_command: Vec<Key>,
+    search_messages: Vec<Key>,
+    toggle_message_filter: Vec<Key>,
+    reverse_message_filter: Vec<Key>,
+    back_to_previous_window: Vec<Key>,
+    scroll_down: Vec<Key>,
+    scroll_up: Vec<Key>,
+    help: Vec<Key>,
+    quit: Vec<Key>,
+    recent_channels_search: Vec<Key>,
+    followed_channels_search: Vec<Key>,
+    crash_application: Vec<Key>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
+pub struct InsertKeybindsConfig {
+    pub fill_suggestion: Vec<Key>,
+    pub confirm_text_input: Vec<Key>,
+    pub back_to_previous_window: Vec<Key>,
+    pub move_cursor_right: Vec<Key>,
+    pub move_cursor_left: Vec<Key>,
+    pub move_cursor_start: Vec<Key>,
+    pub move_cursor_end: Vec<Key>,
+    pub swap_previous_item_with_current: Vec<Key>,
+    pub remove_after_cursor: Vec<Key>,
+    pub remove_before_cursor: Vec<Key>,
+    pub remove_previous_word: Vec<Key>,
+    pub remove_item_to_right: Vec<Key>,
+    pub toggle_message_filter: Vec<Key>,
+    pub reverse_message_filter: Vec<Key>,
+    pub end_of_next_word: Vec<Key>,
+    pub start_of_previous_word: Vec<Key>,
+    pub swap_previous_word_with_current: Vec<Key>,
+    pub toggle_emote_picker: Vec<Key>,
+}
+
 impl Default for TwitchConfig {
     fn default() -> Self {
         Self {
@@ -196,6 +261,64 @@ impl Default for FrontendConfig {
             right_align_usernames: false,
             show_unsupported_screen_size: true,
             only_get_live_followed_channels: false,
+        }
+    }
+}
+
+impl Default for DashboardKeybindsConfig {
+    fn default() -> Self {
+        Self {
+            join: vec![Key::Enter],
+            help: vec![Key::Char('?'), Key::Char('h')],
+            quit: vec![Key::Char('q')],
+            recent_channels_search: vec![Key::Char('s')],
+            followed_channels_search: vec![Key::Char('f')],
+            crash_application: vec![Key::Ctrl('p')],
+        }
+    }
+}
+impl Default for NormalKeybindsConfig {
+    fn default() -> Self {
+        Self {
+            enter_insert: vec![Key::Char('i'), Key::Char('c')],
+            enter_insert_with_mention: vec![Key::Char('@')],
+            enter_insert_with_command: vec![Key::Char('/')],
+            search_messages: vec![Key::Ctrl('f')],
+            toggle_message_filter: vec![Key::Ctrl('t')],
+            reverse_message_filter: vec![Key::Ctrl('r')],
+            back_to_previous_window: vec![Key::Esc],
+            scroll_up: vec![Key::ScrollUp, Key::Up, Key::Char('k')],
+            scroll_down: vec![Key::ScrollDown, Key::Down, Key::Char('j')],
+            help: vec![Key::Char('?'), Key::Char('h')],
+            quit: vec![Key::Char('q')],
+            recent_channels_search: vec![Key::Char('s')],
+            followed_channels_search: vec![Key::Char('f')],
+            crash_application: vec![Key::Ctrl('p')],
+        }
+    }
+}
+
+impl Default for InsertKeybindsConfig {
+    fn default() -> Self {
+        Self {
+            fill_suggestion: vec![Key::Tab],
+            confirm_text_input: vec![Key::Enter],
+            back_to_previous_window: vec![Key::Esc],
+            move_cursor_right: vec![Key::Right, Key::Ctrl('f')],
+            move_cursor_left: vec![Key::Left, Key::Ctrl('b')],
+            move_cursor_start: vec![Key::Home, Key::Ctrl('a')],
+            move_cursor_end: vec![Key::End, Key::Ctrl('e')],
+            swap_previous_item_with_current: vec![Key::Ctrl('t')],
+            remove_after_cursor: vec![Key::Ctrl('k')],
+            remove_before_cursor: vec![Key::Ctrl('u')],
+            remove_previous_word: vec![Key::Ctrl('w')],
+            remove_item_to_right: vec![Key::Delete, Key::Ctrl('d')],
+            toggle_message_filter: vec![Key::Ctrl('t')],
+            reverse_message_filter: vec![Key::Ctrl('r')],
+            end_of_next_word: vec![Key::Alt('f')],
+            start_of_previous_word: vec![Key::Alt('b')],
+            swap_previous_word_with_current: vec![Key::Alt('t')],
+            toggle_emote_picker: vec![Key::Ctrl('e')],
         }
     }
 }

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -148,42 +148,48 @@ pub struct FrontendConfig {
     pub only_get_live_followed_channels: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct KeybindsConfig {
+    pub toggle_debug_focus: Vec<Key>,
     pub dashboard: DashboardKeybindsConfig,
     pub normal: NormalKeybindsConfig,
     pub insert: InsertKeybindsConfig,
+    pub selection: SelectionKeybindsConfig,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct DashboardKeybindsConfig {
-    join: Vec<Key>,
-    help: Vec<Key>,
-    quit: Vec<Key>,
-    recent_channels_search: Vec<Key>,
-    followed_channels_search: Vec<Key>,
-    crash_application: Vec<Key>,
+    pub join: Vec<Key>,
+    pub help: Vec<Key>,
+    pub quit: Vec<Key>,
+    pub recent_channels_search: Vec<Key>,
+    pub followed_channels_search: Vec<Key>,
+    pub crash_application: Vec<Key>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct NormalKeybindsConfig {
-    enter_insert: Vec<Key>,
-    enter_insert_with_mention: Vec<Key>,
-    enter_insert_with_command: Vec<Key>,
-    search_messages: Vec<Key>,
-    toggle_message_filter: Vec<Key>,
-    reverse_message_filter: Vec<Key>,
-    back_to_previous_window: Vec<Key>,
-    scroll_down: Vec<Key>,
-    scroll_up: Vec<Key>,
-    help: Vec<Key>,
-    quit: Vec<Key>,
-    recent_channels_search: Vec<Key>,
-    followed_channels_search: Vec<Key>,
-    crash_application: Vec<Key>,
+    pub enter_insert: Vec<Key>,
+    pub enter_insert_with_mention: Vec<Key>,
+    pub enter_insert_with_command: Vec<Key>,
+    pub enter_dashboard: Vec<Key>,
+    pub search_messages: Vec<Key>,
+    pub toggle_message_filter: Vec<Key>,
+    pub reverse_message_filter: Vec<Key>,
+    pub back_to_previous_window: Vec<Key>,
+    pub scroll_down: Vec<Key>,
+    pub scroll_up: Vec<Key>,
+    pub scroll_to_end: Vec<Key>,
+    pub scroll_to_start: Vec<Key>,
+    pub open_in_browser: Vec<Key>,
+    pub help: Vec<Key>,
+    pub quit: Vec<Key>,
+    pub recent_channels_search: Vec<Key>,
+    pub followed_channels_search: Vec<Key>,
+    pub crash_application: Vec<Key>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -207,6 +213,19 @@ pub struct InsertKeybindsConfig {
     pub start_of_previous_word: Vec<Key>,
     pub swap_previous_word_with_current: Vec<Key>,
     pub toggle_emote_picker: Vec<Key>,
+    pub quit: Vec<Key>,
+    pub crash_application: Vec<Key>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
+pub struct SelectionKeybindsConfig {
+    pub scroll_down: Vec<Key>,
+    pub scroll_up: Vec<Key>,
+    pub delete_entry: Vec<Key>,
+    pub select: Vec<Key>,
+    pub back_to_previous_window: Vec<Key>,
+    pub crash_application: Vec<Key>,
 }
 
 impl Default for TwitchConfig {
@@ -265,6 +284,18 @@ impl Default for FrontendConfig {
     }
 }
 
+impl Default for KeybindsConfig {
+    fn default() -> Self {
+        Self {
+            toggle_debug_focus: vec![Key::Ctrl('d')],
+            dashboard: DashboardKeybindsConfig::default(),
+            normal: NormalKeybindsConfig::default(),
+            insert: InsertKeybindsConfig::default(),
+            selection: SelectionKeybindsConfig::default(),
+        }
+    }
+}
+
 impl Default for DashboardKeybindsConfig {
     fn default() -> Self {
         Self {
@@ -283,12 +314,16 @@ impl Default for NormalKeybindsConfig {
             enter_insert: vec![Key::Char('i'), Key::Char('c')],
             enter_insert_with_mention: vec![Key::Char('@')],
             enter_insert_with_command: vec![Key::Char('/')],
+            enter_dashboard: vec![Key::Char('S')],
             search_messages: vec![Key::Ctrl('f')],
             toggle_message_filter: vec![Key::Ctrl('t')],
             reverse_message_filter: vec![Key::Ctrl('r')],
             back_to_previous_window: vec![Key::Esc],
             scroll_up: vec![Key::ScrollUp, Key::Up, Key::Char('k')],
             scroll_down: vec![Key::ScrollDown, Key::Down, Key::Char('j')],
+            scroll_to_end: vec![Key::Char('G')],
+            scroll_to_start: vec![Key::Char('g')],
+            open_in_browser: vec![Key::Char('o')],
             help: vec![Key::Char('?'), Key::Char('h')],
             quit: vec![Key::Char('q')],
             recent_channels_search: vec![Key::Char('s')],
@@ -319,6 +354,21 @@ impl Default for InsertKeybindsConfig {
             start_of_previous_word: vec![Key::Alt('b')],
             swap_previous_word_with_current: vec![Key::Alt('t')],
             toggle_emote_picker: vec![Key::Ctrl('e')],
+            quit: vec![Key::Ctrl('q')],
+            crash_application: vec![Key::Ctrl('p')],
+        }
+    }
+}
+
+impl Default for SelectionKeybindsConfig {
+    fn default() -> Self {
+        Self {
+            scroll_up: vec![Key::ScrollUp, Key::Up],
+            scroll_down: vec![Key::ScrollDown, Key::Down],
+            select: vec![Key::Enter],
+            delete_entry: vec![Key::Ctrl('d')],
+            back_to_previous_window: vec![Key::Esc],
+            crash_application: vec![Key::Enter],
         }
     }
 }

--- a/src/handlers/context.rs
+++ b/src/handlers/context.rs
@@ -14,7 +14,7 @@ use crate::{
         filters::Filters,
         state::State,
         storage::{SharedStorage, Storage},
-        user_input::events::{Event, Key},
+        user_input::events::Event,
     },
     terminal::TerminalAction,
     ui::components::{Component, Components},
@@ -137,7 +137,13 @@ impl Context {
 
             match key {
                 // Global keybinds
-                Key::Ctrl('d') => {
+                key if self
+                    .config
+                    .borrow()
+                    .keybinds
+                    .toggle_debug_focus
+                    .contains(key) =>
+                {
                     self.components.debug.toggle_focus();
                 }
                 _ => {

--- a/src/handlers/user_input/events.rs
+++ b/src/handlers/user_input/events.rs
@@ -1,11 +1,13 @@
 use std::{fmt::Display, time::Duration};
 
+use serde::{Deserialize, Serialize};
+
 use tokio::{sync::mpsc, time::Instant};
 use tui::crossterm::event::{
     self, Event as CEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEventKind,
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Key {
     // Keyboard controls
     Backspace,

--- a/src/handlers/user_input/events.rs
+++ b/src/handlers/user_input/events.rs
@@ -40,9 +40,9 @@ impl FromStr for Key {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         fn get_single_char(s: &str) -> Result<char, Error> {
             if s.chars().count() == 1 {
-                s.chars().next().expect("Must be a char here");
+                return Ok(s.chars().next().expect("Must be a char here"));
             }
-            bail!("Key '{}' cannot be deserialized", s);
+            bail!("Key char '{}' cannot be deserialized", s);
         }
         match s.to_lowercase().as_str() {
             "esc" => Ok(Self::Esc),
@@ -92,9 +92,9 @@ impl Display for Key {
             Self::End => write!(f, "End"),
             Self::Delete => write!(f, "Delete"),
             Self::Backspace => write!(f, "Backspace"),
-            Self::Null => write!(f, "null"),
             Self::ScrollDown => write!(f, "ScrollDown"),
             Self::ScrollUp => write!(f, "ScrollUp"),
+            Self::Null => unimplemented!(),
         }
     }
 }

--- a/src/handlers/user_input/events.rs
+++ b/src/handlers/user_input/events.rs
@@ -115,7 +115,8 @@ mod tests {
     fn special_key_parsing() {
         assert_eq!(Key::Backspace, Key::from_str("backspace").unwrap());
         assert_eq!(Key::Backspace, Key::from_str("Backspace").unwrap());
-        //TODO fill this in
+        assert_eq!(Key::Esc, Key::from_str("Esc").unwrap());
+        assert_eq!(Key::Esc, Key::from_str("esc").unwrap());
     }
 
     #[test]
@@ -133,16 +134,29 @@ mod tests {
     }
 
     #[test]
-    fn symmetry() {
+    fn key_parsing_display_symmetry() {
+        let mut vec: Vec<Key> = Vec::new();
         for i in '0'..='z' {
-            let key = Key::Char(i);
-            assert_eq!(key, Key::from_str(&key.to_string()).unwrap());
-
-            let key = Key::Ctrl(i);
-            assert_eq!(key, Key::from_str(&key.to_string()).unwrap());
-
-            let key = Key::Alt(i);
-            assert_eq!(key, Key::from_str(&key.to_string()).unwrap());
+            vec.extend_from_slice(&[Key::Char(i), Key::Ctrl(i), Key::Alt(i)]);
+        }
+        vec.extend_from_slice(&[
+            Key::Backspace,
+            Key::Esc,
+            Key::Up,
+            Key::Down,
+            Key::Left,
+            Key::Right,
+            Key::Home,
+            Key::End,
+            Key::Delete,
+            Key::Insert,
+            Key::Tab,
+            Key::Enter,
+            Key::ScrollDown,
+            Key::ScrollUp,
+        ]);
+        for key in &vec {
+            assert_eq!(*key, Key::from_str(&key.to_string()).unwrap())
         }
     }
 }

--- a/src/handlers/user_input/events.rs
+++ b/src/handlers/user_input/events.rs
@@ -101,6 +101,14 @@ impl Display for Key {
     }
 }
 
+pub fn get_keybind_text(keybind: &[Key]) -> String {
+    keybind
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<String>>()
+        .join(" or ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/handlers/user_input/events.rs
+++ b/src/handlers/user_input/events.rs
@@ -45,29 +45,29 @@ impl FromStr for Key {
             bail!("Key '{}' cannot be deserialized", s);
         }
         match s.to_lowercase().as_str() {
-            "esc" => Ok(Key::Esc),
-            "enter" => Ok(Key::Enter),
-            "tab" => Ok(Key::Tab),
-            "insert" => Ok(Key::Insert),
-            "down" => Ok(Key::Down),
-            "up" => Ok(Key::Up),
-            "left" => Ok(Key::Left),
-            "right" => Ok(Key::Right),
-            "home" => Ok(Key::Home),
-            "end" => Ok(Key::End),
-            "delete" => Ok(Key::Delete),
-            "backspace" => Ok(Key::Backspace),
-            "scrolldown" => Ok(Key::ScrollDown),
-            "scrollup" => Ok(Key::ScrollUp),
+            "esc" => Ok(Self::Esc),
+            "enter" => Ok(Self::Enter),
+            "tab" => Ok(Self::Tab),
+            "insert" => Ok(Self::Insert),
+            "down" => Ok(Self::Down),
+            "up" => Ok(Self::Up),
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "home" => Ok(Self::Home),
+            "end" => Ok(Self::End),
+            "delete" => Ok(Self::Delete),
+            "backspace" => Ok(Self::Backspace),
+            "scrolldown" => Ok(Self::ScrollDown),
+            "scrollup" => Ok(Self::ScrollUp),
             _ => {
                 if let Some((modifier, key)) = s.split_once('+') {
-                    return match modifier.trim() {
-                        "alt" => Ok(Key::Alt(get_single_char(key)?)),
-                        "ctrl" => Ok(Key::Ctrl(get_single_char(key)?)),
+                    match modifier.trim() {
+                        "alt" => Ok(Self::Alt(get_single_char(key)?)),
+                        "ctrl" => Ok(Self::Ctrl(get_single_char(key)?)),
                         _ => bail!("Key '{}' cannot be deserialized", s),
-                    };
+                    }
                 } else {
-                    return Ok(Key::Char(get_single_char(s)?));
+                    Ok(Self::Char(get_single_char(s)?))
                 }
             }
         }
@@ -77,9 +77,9 @@ impl FromStr for Key {
 impl Display for Key {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Char(c) => write!(f, "{}", c),
-            Self::Ctrl(c) => write!(f, "Ctrl+{}", c),
-            Self::Alt(c) => write!(f, "Alt+{}", c),
+            Self::Char(c) => write!(f, "{c}"),
+            Self::Ctrl(c) => write!(f, "Ctrl+{c}"),
+            Self::Alt(c) => write!(f, "Alt+{c}"),
             Self::Esc => write!(f, "Esc"),
             Self::Enter => write!(f, "Enter"),
             Self::Tab => write!(f, "Tab"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
     let cloned_config = config.clone();
 
     tokio::task::spawn(async move {
-        if let Err(err) = twitch::twitch_websocket(config, twitch_tx, twitch_rx).await {
+        if let Err(err) = Box::pin(twitch::twitch_websocket(config, twitch_tx, twitch_rx)).await {
             error!("Error when running Twitch websocket client: {err}");
         }
     });

--- a/src/ui/components/channel_switcher.rs
+++ b/src/ui/components/channel_switcher.rs
@@ -260,9 +260,9 @@ impl Component for ChannelSwitcherWidget {
                 key if keybinds.crash_application.contains(key) => {
                     panic!("Manual panic triggered by user.")
                 }
-                key if keybinds.scroll_down.contains(key) => self.next(),
-                key if keybinds.scroll_up.contains(key) => self.previous(),
-                key if keybinds.delete_entry.contains(key) => {
+                key if keybinds.next_item.contains(key) => self.next(),
+                key if keybinds.prev_item.contains(key) => self.previous(),
+                key if keybinds.delete_item.contains(key) => {
                     if let Some(index) = self.list_state.selected() {
                         // TODO: Make this just two if lets
                         if let Some(filtered) = self.filtered_channels.clone() {

--- a/src/ui/components/channel_switcher.rs
+++ b/src/ui/components/channel_switcher.rs
@@ -16,11 +16,7 @@ use tui::{
 };
 
 use crate::{
-    handlers::{
-        config::SharedCoreConfig,
-        storage::SharedStorage,
-        user_input::events::{Event, Key},
-    },
+    handlers::{config::SharedCoreConfig, storage::SharedStorage, user_input::events::Event},
     terminal::TerminalAction,
     twitch::TwitchAction,
     ui::{
@@ -248,9 +244,9 @@ impl Component for ChannelSwitcherWidget {
         self.search_input.draw(f, Some(input_rect));
     }
 
+    #[allow(clippy::cognitive_complexity)]
     async fn event(&mut self, event: &Event) -> Option<TerminalAction> {
         if let Event::Input(key) = event {
-            //TODO ig this needs its own widget keybinds
             let keybinds = self.config.borrow().keybinds.selection.clone();
             match key {
                 key if keybinds.back_to_previous_window.contains(key) => {
@@ -283,7 +279,7 @@ impl Component for ChannelSwitcherWidget {
                         }
                     }
                 }
-                Key::Enter => {
+                key if keybinds.select.contains(key) => {
                     // TODO: Reduce code duplication
                     if let Some(i) = self.list_state.selected() {
                         self.toggle_focus();

--- a/src/ui/components/channel_switcher.rs
+++ b/src/ui/components/channel_switcher.rs
@@ -250,8 +250,10 @@ impl Component for ChannelSwitcherWidget {
 
     async fn event(&mut self, event: &Event) -> Option<TerminalAction> {
         if let Event::Input(key) = event {
+            //TODO ig this needs its own widget keybinds
+            let keybinds = self.config.borrow().keybinds.selection.clone();
             match key {
-                Key::Esc => {
+                key if keybinds.back_to_previous_window.contains(key) => {
                     if self.list_state.selected().is_some() {
                         self.unselect();
                     } else {
@@ -259,10 +261,12 @@ impl Component for ChannelSwitcherWidget {
                         self.search_input.clear();
                     }
                 }
-                Key::Ctrl('p') => panic!("Manual panic triggered by user."),
-                Key::ScrollDown | Key::Down => self.next(),
-                Key::ScrollUp | Key::Up => self.previous(),
-                Key::Ctrl('d') => {
+                key if keybinds.crash_application.contains(key) => {
+                    panic!("Manual panic triggered by user.")
+                }
+                key if keybinds.scroll_down.contains(key) => self.next(),
+                key if keybinds.scroll_up.contains(key) => self.previous(),
+                key if keybinds.delete_entry.contains(key) => {
                     if let Some(index) = self.list_state.selected() {
                         // TODO: Make this just two if lets
                         if let Some(filtered) = self.filtered_channels.clone() {

--- a/src/ui/components/chat_input.rs
+++ b/src/ui/components/chat_input.rs
@@ -4,11 +4,7 @@ use tui::{Frame, layout::Rect};
 
 use crate::{
     emotes::SharedEmotes,
-    handlers::{
-        config::SharedCoreConfig,
-        storage::SharedStorage,
-        user_input::events::{Event, Key},
-    },
+    handlers::{config::SharedCoreConfig, storage::SharedStorage, user_input::events::Event},
     terminal::TerminalAction,
     twitch::TwitchAction,
     ui::{
@@ -128,8 +124,9 @@ impl Component for ChatInputWidget {
                 self.input.insert(" ");
             }
         } else if let Event::Input(key) = event {
+            let keybinds = self.config.borrow().keybinds.insert.clone();
             match key {
-                Key::Enter => {
+                key if keybinds.confirm_text_input.contains(key) => {
                     if self.input.is_valid() {
                         let current_input = self.input.to_string();
 
@@ -149,12 +146,12 @@ impl Component for ChatInputWidget {
                         return Some(action);
                     }
                 }
-                Key::Alt('e') => {
+                key if keybinds.toggle_emote_picker.contains(key) => {
                     if self.config.borrow().frontend.is_emotes_enabled() {
                         self.emote_picker.toggle_focus();
                     }
                 }
-                Key::Esc => {
+                key if keybinds.back_to_previous_window.contains(key) => {
                     self.input.toggle_focus();
                 }
                 _ => {

--- a/src/ui/components/dashboard.rs
+++ b/src/ui/components/dashboard.rs
@@ -14,7 +14,7 @@ use crate::{
         config::SharedCoreConfig,
         state::State,
         storage::SharedStorage,
-        user_input::events::{Event, Key},
+        user_input::events::{Event, Key, get_keybind_text},
     },
     terminal::TerminalAction,
     twitch::TwitchAction,
@@ -113,7 +113,7 @@ impl DashboardWidget {
         let current_channel_selection = Paragraph::new(Line::from(vec![
             Span::raw("["),
             Span::styled(
-                "ENTER".to_string(),
+                get_keybind_text(&self.config.borrow().keybinds.dashboard.join),
                 Style::default().fg(Color::LightMagenta),
             ),
             Span::raw("] "),
@@ -155,7 +155,10 @@ impl DashboardWidget {
     fn render_quit_selection_widget(&self, frame: &mut Frame, v_chunks: &mut Iter<Rect>) {
         let quit_option = Paragraph::new(Line::from(vec![
             Span::raw("["),
-            Span::styled("q", Style::default().fg(Color::LightMagenta)),
+            Span::styled(
+                get_keybind_text(&self.config.borrow().keybinds.dashboard.quit),
+                Style::default().fg(Color::LightMagenta),
+            ),
             Span::raw("] "),
             Span::raw("Quit"),
         ]));

--- a/src/ui/components/dashboard.rs
+++ b/src/ui/components/dashboard.rs
@@ -235,19 +235,28 @@ impl Component for DashboardWidget {
                 return self.following.event(event).await;
             }
 
+            let keybinds = self.config.borrow().keybinds.dashboard.clone();
             match key {
-                Key::Ctrl('p') => panic!("Manual panic triggered by user."),
-                Key::Char('q') => return Some(TerminalAction::Quit),
-                Key::Char('s') => self.channel_input.toggle_focus(),
-                Key::Char('f') => self.following.toggle_focus().await,
-                Key::Enter => {
+                key if keybinds.crash_application.contains(key) => {
+                    panic!("Manual panic triggered by user.");
+                }
+                key if keybinds.quit.contains(key) => return Some(TerminalAction::Quit),
+                key if keybinds.recent_channels_search.contains(key) => {
+                    self.channel_input.toggle_focus();
+                }
+                key if keybinds.followed_channels_search.contains(key) => {
+                    self.following.toggle_focus().await;
+                }
+                key if keybinds.join.contains(key) => {
                     let action = TerminalAction::Enter(TwitchAction::JoinChannel(
                         self.config.borrow().twitch.channel.clone(),
                     ));
 
                     return Some(action);
                 }
-                Key::Char('?' | 'h') => return Some(TerminalAction::SwitchState(State::Help)),
+                key if keybinds.help.contains(key) => {
+                    return Some(TerminalAction::SwitchState(State::Help));
+                }
                 Key::Char(c) => {
                     if let Some(digit) = c.to_digit(10) {
                         let mut channels = self.config.borrow().frontend.favorite_channels.clone();

--- a/src/ui/components/debug.rs
+++ b/src/ui/components/debug.rs
@@ -9,7 +9,7 @@ use tui::{
 use crate::{
     handlers::{
         config::{SharedCoreConfig, ToVec},
-        user_input::events::{Event, Key},
+        user_input::events::Event,
     },
     terminal::TerminalAction,
     ui::components::Component,
@@ -116,14 +116,17 @@ impl Component for DebugWidget {
 
     async fn event(&mut self, event: &Event) -> Option<TerminalAction> {
         if let Event::Input(key) = event {
+            let keybinds = self.config.borrow().keybinds.normal.clone();
             match key {
-                Key::Char('q') => return Some(TerminalAction::Quit),
-                Key::Esc => {
+                key if keybinds.quit.contains(key) => return Some(TerminalAction::Quit),
+                key if keybinds.back_to_previous_window.contains(key) => {
                     self.toggle_focus();
 
                     return Some(TerminalAction::BackOneLayer);
                 }
-                Key::Ctrl('p') => panic!("Manual panic triggered by user."),
+                key if keybinds.crash_application.contains(key) => {
+                    panic!("Manual panic triggered by user.")
+                }
                 _ => {}
             }
         }

--- a/src/ui/components/emote_picker.rs
+++ b/src/ui/components/emote_picker.rs
@@ -13,10 +13,7 @@ use tui::{
 use super::utils::popup_area;
 use crate::{
     emotes::{SharedEmotes, load_picker_emote},
-    handlers::{
-        config::SharedCoreConfig,
-        user_input::events::{Event, Key},
-    },
+    handlers::{config::SharedCoreConfig, user_input::events::Event},
     terminal::TerminalAction,
     twitch::TwitchAction,
     ui::{
@@ -250,12 +247,15 @@ impl Component for EmotePickerWidget {
 
     async fn event(&mut self, event: &Event) -> Option<TerminalAction> {
         if let Event::Input(key) = event {
+            let keybinds = self.config.borrow().keybinds.selection.clone();
             match key {
-                Key::Esc => self.toggle_focus(),
-                Key::Ctrl('p') => panic!("Manual panic triggered by user."),
-                Key::ScrollDown | Key::Down => self.next(),
-                Key::ScrollUp | Key::Up => self.previous(),
-                Key::Enter => {
+                key if keybinds.back_to_previous_window.contains(key) => self.toggle_focus(),
+                key if keybinds.crash_application.contains(key) => {
+                    panic!("Manual panic triggered by user.")
+                }
+                key if keybinds.scroll_down.contains(key) => self.next(),
+                key if keybinds.scroll_up.contains(key) => self.previous(),
+                key if keybinds.select.contains(key) => {
                     if let Some(idx) = self.list_state.selected() {
                         let emote = self.filtered_emotes[idx].clone();
 

--- a/src/ui/components/emote_picker.rs
+++ b/src/ui/components/emote_picker.rs
@@ -253,8 +253,8 @@ impl Component for EmotePickerWidget {
                 key if keybinds.crash_application.contains(key) => {
                     panic!("Manual panic triggered by user.")
                 }
-                key if keybinds.scroll_down.contains(key) => self.next(),
-                key if keybinds.scroll_up.contains(key) => self.previous(),
+                key if keybinds.next_item.contains(key) => self.next(),
+                key if keybinds.prev_item.contains(key) => self.previous(),
                 key if keybinds.select.contains(key) => {
                     if let Some(idx) = self.list_state.selected() {
                         let emote = self.filtered_emotes[idx].clone();

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -5,7 +5,13 @@ use tui::{
 };
 
 use crate::{
-    handlers::{config::SharedCoreConfig, user_input::events::{Event, Key}}, terminal::TerminalAction, ui::{components::Component, statics::HELP_COLUMN_TITLES}, utils::styles::{BOLD_STYLE, COLUMN_TITLE_STYLE}
+    handlers::{
+        config::SharedCoreConfig,
+        user_input::events::{Event, Key},
+    },
+    terminal::TerminalAction,
+    ui::{components::Component, statics::HELP_COLUMN_TITLES},
+    utils::styles::{BOLD_STYLE, COLUMN_TITLE_STYLE},
 };
 
 // Once a solution is found to calculate constraints, this will be removed.
@@ -276,8 +282,12 @@ impl Component for HelpWidget {
             let keybinds = self.config.borrow().keybinds.selection.clone();
             match key {
                 key if keybinds.quit.contains(key) => return Some(TerminalAction::Quit),
-                key if keybinds.back_to_previous_window.contains(key) => return Some(TerminalAction::BackOneLayer),
-                key if keybinds.crash_application.contains(key) => panic!("Manual panic triggered by user."),
+                key if keybinds.back_to_previous_window.contains(key) => {
+                    return Some(TerminalAction::BackOneLayer);
+                }
+                key if keybinds.crash_application.contains(key) => {
+                    panic!("Manual panic triggered by user.")
+                }
                 _ => {}
             }
         }

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -7,7 +7,7 @@ use tui::{
 use crate::{
     handlers::{
         config::SharedCoreConfig,
-        user_input::events::{Event, Key},
+        user_input::events::{Event, get_keybind_text},
     },
     terminal::TerminalAction,
     ui::{components::Component, statics::HELP_COLUMN_TITLES},
@@ -28,207 +28,209 @@ impl HelpWidget {
         Self { config }
     }
     fn get_help_keybinds(&self) -> Vec<(&'static str, Vec<(String, &'static str)>)> {
-        fn get_key_text(keybind: &[Key]) -> String {
-            keybind
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<String>>()
-                .join(" or ")
-        }
         let keybinds = self.config.borrow().keybinds.clone();
         let dashboard_keybinds = vec![
             (
-                get_key_text(&keybinds.dashboard.join),
+                get_keybind_text(&keybinds.dashboard.join),
                 "Join the selected channel",
             ),
             (
-                get_key_text(&keybinds.dashboard.recent_channels_search),
+                get_keybind_text(&keybinds.dashboard.recent_channels_search),
                 "Open the recent channel search popup",
             ),
             (
-                get_key_text(&keybinds.dashboard.followed_channels_search),
+                get_keybind_text(&keybinds.dashboard.followed_channels_search),
                 "Open the followed channel search popup",
             ),
             (
-                get_key_text(&keybinds.dashboard.help),
+                get_keybind_text(&keybinds.dashboard.help),
                 "Have the keybinds popup window appear",
             ),
             (
-                get_key_text(&keybinds.dashboard.quit),
+                get_keybind_text(&keybinds.dashboard.quit),
                 "Quit the application",
             ),
             (
-                get_key_text(&keybinds.dashboard.crash_application),
+                get_keybind_text(&keybinds.dashboard.crash_application),
                 "Manually crash the application",
             ),
         ];
         let normal_keybinds = vec![
             (
-                get_key_text(&keybinds.normal.enter_insert),
+                get_keybind_text(&keybinds.normal.enter_insert),
                 "Enter message (chat) mode for sending messages",
             ),
             (
-                get_key_text(&keybinds.normal.enter_insert_with_mention),
+                get_keybind_text(&keybinds.normal.enter_insert_with_mention),
                 "Messaging mode with mention symbol",
             ),
             (
-                get_key_text(&keybinds.normal.enter_insert_with_command),
+                get_keybind_text(&keybinds.normal.enter_insert_with_command),
                 "Messaging mode with command symbol",
             ),
             (
-                get_key_text(&keybinds.normal.enter_dashboard),
+                get_keybind_text(&keybinds.normal.enter_dashboard),
                 "Go to the dashboard screen (start screen)",
             ),
             (
-                get_key_text(&keybinds.normal.search_messages),
+                get_keybind_text(&keybinds.normal.search_messages),
                 "Search messages",
             ),
             (
-                get_key_text(&keybinds.normal.toggle_message_filter),
+                get_keybind_text(&keybinds.normal.toggle_message_filter),
                 "Toggle the message filter",
             ),
             (
-                get_key_text(&keybinds.normal.reverse_message_filter),
+                get_keybind_text(&keybinds.normal.reverse_message_filter),
                 "Reverse the message filter",
             ),
             (
-                get_key_text(&keybinds.normal.back_to_previous_window),
+                get_keybind_text(&keybinds.normal.back_to_previous_window),
                 "Go back to the previous window",
             ),
             (
-                get_key_text(&keybinds.normal.scroll_down),
+                get_keybind_text(&keybinds.normal.scroll_down),
                 "Scroll chat down",
             ),
-            (get_key_text(&keybinds.normal.scroll_up), "Scroll chat up"),
             (
-                get_key_text(&keybinds.normal.scroll_to_start),
+                get_keybind_text(&keybinds.normal.scroll_up),
+                "Scroll chat up",
+            ),
+            (
+                get_keybind_text(&keybinds.normal.scroll_to_start),
                 "Scroll chat to top",
             ),
             (
-                get_key_text(&keybinds.normal.scroll_to_end),
+                get_keybind_text(&keybinds.normal.scroll_to_end),
                 "Scroll chat to bottom",
             ),
             (
-                get_key_text(&keybinds.normal.open_in_browser),
+                get_keybind_text(&keybinds.normal.open_in_browser),
                 "Open current stream in browser",
             ),
             (
-                get_key_text(&keybinds.normal.recent_channels_search),
+                get_keybind_text(&keybinds.normal.recent_channels_search),
                 "Open the recent channel search widget",
             ),
             (
-                get_key_text(&keybinds.normal.followed_channels_search),
+                get_keybind_text(&keybinds.normal.followed_channels_search),
                 "Open the followed channel search widget",
             ),
-            (get_key_text(&keybinds.normal.help), "* You are here!"),
-            (get_key_text(&keybinds.normal.quit), "Quit the application"),
+            (get_keybind_text(&keybinds.normal.help), "* You are here!"),
             (
-                get_key_text(&keybinds.normal.crash_application),
+                get_keybind_text(&keybinds.normal.quit),
+                "Quit the application",
+            ),
+            (
+                get_keybind_text(&keybinds.normal.crash_application),
                 "Manually crash the application",
             ),
         ];
         let insert_keybinds = vec![
             (
-                get_key_text(&keybinds.insert.fill_suggestion),
+                get_keybind_text(&keybinds.insert.fill_suggestion),
                 "Fill in suggestion, if available",
             ),
             (
-                get_key_text(&keybinds.insert.confirm_text_input),
+                get_keybind_text(&keybinds.insert.confirm_text_input),
                 "Confirm the input text to go through",
             ),
             (
-                get_key_text(&keybinds.insert.back_to_previous_window),
+                get_keybind_text(&keybinds.insert.back_to_previous_window),
                 "Go back to the previous window",
             ),
             (
-                get_key_text(&keybinds.insert.move_cursor_right),
+                get_keybind_text(&keybinds.insert.move_cursor_right),
                 "Move cursor to the right",
             ),
             (
-                get_key_text(&keybinds.insert.move_cursor_left),
+                get_keybind_text(&keybinds.insert.move_cursor_left),
                 "Move cursor to the left",
             ),
             (
-                get_key_text(&keybinds.insert.move_cursor_start),
+                get_keybind_text(&keybinds.insert.move_cursor_start),
                 "Move cursor to the start",
             ),
             (
-                get_key_text(&keybinds.insert.move_cursor_end),
+                get_keybind_text(&keybinds.insert.move_cursor_end),
                 "Move cursor to the end",
             ),
             (
-                get_key_text(&keybinds.insert.swap_previous_item_with_current),
+                get_keybind_text(&keybinds.insert.swap_previous_item_with_current),
                 "Swap previous item with current item",
             ),
             (
-                get_key_text(&keybinds.insert.remove_after_cursor),
+                get_keybind_text(&keybinds.insert.remove_after_cursor),
                 "Remove everything after the cursor",
             ),
             (
-                get_key_text(&keybinds.insert.remove_before_cursor),
+                get_keybind_text(&keybinds.insert.remove_before_cursor),
                 "Remove everything before the cursor",
             ),
             (
-                get_key_text(&keybinds.insert.remove_previous_word),
+                get_keybind_text(&keybinds.insert.remove_previous_word),
                 "Remove the previous word",
             ),
             (
-                get_key_text(&keybinds.insert.remove_item_to_right),
+                get_keybind_text(&keybinds.insert.remove_item_to_right),
                 "Remove item to the right",
             ),
             (
-                get_key_text(&keybinds.insert.toggle_message_filter),
+                get_keybind_text(&keybinds.insert.toggle_message_filter),
                 "Toggle the filter",
             ),
             (
-                get_key_text(&keybinds.insert.reverse_message_filter),
+                get_keybind_text(&keybinds.insert.reverse_message_filter),
                 "Reverse the filter",
             ),
             (
-                get_key_text(&keybinds.insert.end_of_next_word),
+                get_keybind_text(&keybinds.insert.end_of_next_word),
                 "Move to the end of the next word",
             ),
             (
-                get_key_text(&keybinds.insert.start_of_previous_word),
+                get_keybind_text(&keybinds.insert.start_of_previous_word),
                 "Move to the start of the previous word",
             ),
             (
-                get_key_text(&keybinds.insert.swap_previous_word_with_current),
+                get_keybind_text(&keybinds.insert.swap_previous_word_with_current),
                 "Swap previous word with current word",
             ),
             (
-                get_key_text(&keybinds.insert.toggle_emote_picker),
+                get_keybind_text(&keybinds.insert.toggle_emote_picker),
                 "Toggle emote picker",
             ),
-            (get_key_text(&keybinds.insert.quit), "Quit the application"),
             (
-                get_key_text(&keybinds.insert.crash_application),
+                get_keybind_text(&keybinds.insert.quit),
+                "Quit the application",
+            ),
+            (
+                get_keybind_text(&keybinds.insert.crash_application),
                 "Manually crash the application",
             ),
         ];
         let selection_keybinds = vec![
             (
-                get_key_text(&keybinds.selection.next_item),
+                get_keybind_text(&keybinds.selection.next_item),
                 "Move selection to next item",
             ),
             (
-                get_key_text(&keybinds.selection.prev_item),
+                get_keybind_text(&keybinds.selection.prev_item),
                 "Move selection to previous item",
             ),
             (
-                get_key_text(&keybinds.selection.delete_item),
+                get_keybind_text(&keybinds.selection.delete_item),
                 "Delete the currently selected item",
             ),
             (
-                get_key_text(&keybinds.selection.select),
+                get_keybind_text(&keybinds.selection.select),
                 "Confirm the currently selected item",
             ),
             (
-                get_key_text(&keybinds.selection.back_to_previous_window),
+                get_keybind_text(&keybinds.selection.back_to_previous_window),
                 "Go back to the previous window",
             ),
             (
-                get_key_text(&keybinds.selection.crash_application),
+                get_keybind_text(&keybinds.selection.crash_application),
                 "Manually crash the application",
             ),
         ];

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -5,11 +5,8 @@ use tui::{
 };
 
 use crate::{
-    handlers::config::SharedCoreConfig,
-    ui::{
-        components::Component,
-        statics::{HELP_COLUMN_TITLES, HELP_KEYBINDS},
-    },
+    handlers::{config::SharedCoreConfig, user_input::events::Key},
+    ui::{components::Component, statics::HELP_COLUMN_TITLES},
     utils::styles::{BOLD_STYLE, COLUMN_TITLE_STYLE},
 };
 
@@ -26,6 +23,218 @@ impl HelpWidget {
     pub const fn new(config: SharedCoreConfig) -> Self {
         Self { config }
     }
+    fn get_help_keybinds(&self) -> Vec<(&'static str, Vec<(String, &'static str)>)> {
+        fn get_key_text(keybind: &[Key]) -> String {
+            keybind
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+                .join(" or ")
+        }
+        let keybinds = self.config.borrow().keybinds.clone();
+        let dashboard_keybinds = vec![
+            (
+                get_key_text(&keybinds.dashboard.join),
+                "Join the selected channel",
+            ),
+            (
+                get_key_text(&keybinds.dashboard.recent_channels_search),
+                "Open the recent channel search popup",
+            ),
+            (
+                get_key_text(&keybinds.dashboard.followed_channels_search),
+                "Open the followed channel search popup",
+            ),
+            (
+                get_key_text(&keybinds.dashboard.help),
+                "Have the keybinds popup window appear",
+            ),
+            (
+                get_key_text(&keybinds.dashboard.quit),
+                "Quit the application",
+            ),
+            (
+                get_key_text(&keybinds.dashboard.crash_application),
+                "Manually crash the application",
+            ),
+        ];
+        let normal_keybinds = vec![
+            (
+                get_key_text(&keybinds.normal.enter_insert),
+                "Enter message (chat) mode for sending messages",
+            ),
+            (
+                get_key_text(&keybinds.normal.enter_insert_with_mention),
+                "Messaging mode with mention symbol",
+            ),
+            (
+                get_key_text(&keybinds.normal.enter_insert_with_command),
+                "Messaging mode with command symbol",
+            ),
+            (
+                get_key_text(&keybinds.normal.enter_dashboard),
+                "Go to the dashboard screen (start screen)",
+            ),
+            (
+                get_key_text(&keybinds.normal.search_messages),
+                "Search messages",
+            ),
+            (
+                get_key_text(&keybinds.normal.toggle_message_filter),
+                "Toggle the message filter",
+            ),
+            (
+                get_key_text(&keybinds.normal.reverse_message_filter),
+                "Reverse the message filter",
+            ),
+            (
+                get_key_text(&keybinds.normal.back_to_previous_window),
+                "Go back to the previous window",
+            ),
+            (
+                get_key_text(&keybinds.normal.scroll_down),
+                "Scroll chat down",
+            ),
+            (get_key_text(&keybinds.normal.scroll_up), "Scroll chat up"),
+            (
+                get_key_text(&keybinds.normal.scroll_to_start),
+                "Scroll chat to top",
+            ),
+            (
+                get_key_text(&keybinds.normal.scroll_to_end),
+                "Scroll chat to bottom",
+            ),
+            (
+                get_key_text(&keybinds.normal.open_in_browser),
+                "Open current stream in browser",
+            ),
+            (
+                get_key_text(&keybinds.normal.recent_channels_search),
+                "Open the recent channel search widget",
+            ),
+            (
+                get_key_text(&keybinds.normal.followed_channels_search),
+                "Open the followed channel search widget",
+            ),
+            (get_key_text(&keybinds.normal.help), "* You are here!"),
+            (get_key_text(&keybinds.normal.quit), "Quit the application"),
+            (
+                get_key_text(&keybinds.normal.crash_application),
+                "Manually crash the application",
+            ),
+        ];
+        let insert_keybinds = vec![
+            (
+                get_key_text(&keybinds.insert.fill_suggestion),
+                "Fill in suggestion, if available",
+            ),
+            (
+                get_key_text(&keybinds.insert.confirm_text_input),
+                "Confirm the input text to go through",
+            ),
+            (
+                get_key_text(&keybinds.insert.back_to_previous_window),
+                "Go back to the previous window",
+            ),
+            (
+                get_key_text(&keybinds.insert.move_cursor_right),
+                "Move cursor to the right",
+            ),
+            (
+                get_key_text(&keybinds.insert.move_cursor_left),
+                "Move cursor to the left",
+            ),
+            (
+                get_key_text(&keybinds.insert.move_cursor_start),
+                "Move cursor to the start",
+            ),
+            (
+                get_key_text(&keybinds.insert.move_cursor_end),
+                "Move cursor to the end",
+            ),
+            (
+                get_key_text(&keybinds.insert.swap_previous_item_with_current),
+                "Swap previous item with current item",
+            ),
+            (
+                get_key_text(&keybinds.insert.remove_after_cursor),
+                "Remove everything after the cursor",
+            ),
+            (
+                get_key_text(&keybinds.insert.remove_before_cursor),
+                "Remove everything before the cursor",
+            ),
+            (
+                get_key_text(&keybinds.insert.remove_previous_word),
+                "Remove the previous word",
+            ),
+            (
+                get_key_text(&keybinds.insert.remove_item_to_right),
+                "Remove item to the right",
+            ),
+            (
+                get_key_text(&keybinds.insert.toggle_message_filter),
+                "Toggle the filter",
+            ),
+            (
+                get_key_text(&keybinds.insert.reverse_message_filter),
+                "Reverse the filter",
+            ),
+            (
+                get_key_text(&keybinds.insert.end_of_next_word),
+                "Move to the end of the next word",
+            ),
+            (
+                get_key_text(&keybinds.insert.start_of_previous_word),
+                "Move to the start of the previous word",
+            ),
+            (
+                get_key_text(&keybinds.insert.swap_previous_word_with_current),
+                "Swap previous word with current word",
+            ),
+            (
+                get_key_text(&keybinds.insert.toggle_emote_picker),
+                "Toggle emote picker",
+            ),
+            (get_key_text(&keybinds.insert.quit), "Quit the application"),
+            (
+                get_key_text(&keybinds.insert.crash_application),
+                "Manually crash the application",
+            ),
+        ];
+        let selection_keybinds = vec![
+            (
+                get_key_text(&keybinds.selection.next_item),
+                "Move selection to next item",
+            ),
+            (
+                get_key_text(&keybinds.selection.prev_item),
+                "Move selection to previous item",
+            ),
+            (
+                get_key_text(&keybinds.selection.delete_item),
+                "Delete the currently selected item",
+            ),
+            (
+                get_key_text(&keybinds.selection.select),
+                "Confirm the currently selected item",
+            ),
+            (
+                get_key_text(&keybinds.selection.back_to_previous_window),
+                "Go back to the previous window",
+            ),
+            (
+                get_key_text(&keybinds.selection.crash_application),
+                "Manually crash the application",
+            ),
+        ];
+        vec![
+            ("Dashboard", dashboard_keybinds),
+            ("Normal mode", normal_keybinds),
+            ("Insert modes", insert_keybinds),
+            ("Selections", selection_keybinds),
+        ]
+    }
 }
 
 impl Component for HelpWidget {
@@ -34,7 +243,7 @@ impl Component for HelpWidget {
 
         let mut rows = vec![];
 
-        for (s, v) in HELP_KEYBINDS.iter() {
+        for (s, v) in &self.get_help_keybinds() {
             for (i, (key, desc)) in v.iter().enumerate() {
                 rows.push(Row::new(vec![
                     if i == 0 {

--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -5,9 +5,7 @@ use tui::{
 };
 
 use crate::{
-    handlers::{config::SharedCoreConfig, user_input::events::Key},
-    ui::{components::Component, statics::HELP_COLUMN_TITLES},
-    utils::styles::{BOLD_STYLE, COLUMN_TITLE_STYLE},
+    handlers::{config::SharedCoreConfig, user_input::events::{Event, Key}}, terminal::TerminalAction, ui::{components::Component, statics::HELP_COLUMN_TITLES}, utils::styles::{BOLD_STYLE, COLUMN_TITLE_STYLE}
 };
 
 // Once a solution is found to calculate constraints, this will be removed.
@@ -271,5 +269,19 @@ impl Component for HelpWidget {
             .column_spacing(2);
 
         f.render_widget(help_table, r);
+    }
+    //TODO should be default impl if not for the config requirement
+    async fn event(&mut self, event: &Event) -> Option<TerminalAction> {
+        if let Event::Input(key) = event {
+            let keybinds = self.config.borrow().keybinds.selection.clone();
+            match key {
+                key if keybinds.quit.contains(key) => return Some(TerminalAction::Quit),
+                key if keybinds.back_to_previous_window.contains(key) => return Some(TerminalAction::BackOneLayer),
+                key if keybinds.crash_application.contains(key) => panic!("Manual panic triggered by user."),
+                _ => {}
+            }
+        }
+
+        None
     }
 }

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -50,6 +50,7 @@ pub trait Component {
     fn draw(&mut self, f: &mut Frame, area: Option<Rect>);
 
     #[allow(clippy::unused_async)]
+    //TODO make this somehow work with keybinds
     async fn event(&mut self, event: &Event) -> Option<TerminalAction> {
         if let Event::Input(key) = event {
             match key {

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -29,11 +29,8 @@ use tui::{Frame, layout::Rect};
 use crate::{
     emotes::SharedEmotes,
     handlers::{
-        config::SharedCoreConfig,
-        context::SharedMessages,
-        filters::SharedFilters,
-        storage::SharedStorage,
-        user_input::events::{Event, Key},
+        config::SharedCoreConfig, context::SharedMessages, filters::SharedFilters,
+        storage::SharedStorage, user_input::events::Event,
     },
     terminal::TerminalAction,
 };
@@ -50,19 +47,7 @@ pub trait Component {
     fn draw(&mut self, f: &mut Frame, area: Option<Rect>);
 
     #[allow(clippy::unused_async)]
-    //TODO make this somehow work with keybinds
-    async fn event(&mut self, event: &Event) -> Option<TerminalAction> {
-        if let Event::Input(key) = event {
-            match key {
-                Key::Char('q') => return Some(TerminalAction::Quit),
-                Key::Esc => return Some(TerminalAction::BackOneLayer),
-                Key::Ctrl('p') => panic!("Manual panic triggered by user."),
-                _ => {}
-            }
-        }
-
-        None
-    }
+    async fn event(&mut self, event: &Event) -> Option<TerminalAction>;
 }
 
 pub struct Components {
@@ -88,7 +73,8 @@ impl Components {
         emotes: &SharedEmotes,
         startup_time: DateTime<Local>,
     ) -> Self {
-        let window_size_error = ErrorWidget::new(WINDOW_SIZE_TOO_SMALL_ERROR.to_vec());
+        let window_size_error =
+            ErrorWidget::new(config.clone(), WINDOW_SIZE_TOO_SMALL_ERROR.to_vec());
 
         Self {
             tabs: StateTabsWidget::new(config.clone()),

--- a/src/ui/components/utils/input_widget.rs
+++ b/src/ui/components/utils/input_widget.rs
@@ -234,22 +234,22 @@ impl<T: Clone> Component for InputWidget<T> {
                 key if keybinds.end_of_next_word.contains(key) => {
                     self.input.move_to_next_word(At::AfterEnd, Word::Emacs, 1);
                 }
-                Key::Alt('b') => {
+                key if keybinds.start_of_previous_word.contains(key) => {
                     self.input.move_to_prev_word(Word::Emacs, 1);
                 }
-                Key::Ctrl('t') => {
+                key if keybinds.swap_previous_item_with_current.contains(key) => {
                     self.input.transpose_chars(&mut self.input_listener);
                 }
-                Key::Alt('t') => {
+                key if keybinds.swap_previous_word_with_current.contains(key) => {
                     self.input.transpose_words(1, &mut self.input_listener);
                 }
-                Key::Ctrl('u') => {
+                key if keybinds.remove_before_cursor.contains(key) => {
                     self.input.discard_line(&mut self.input_listener);
                 }
-                Key::Ctrl('k') => {
+                key if keybinds.remove_after_cursor.contains(key) => {
                     self.input.kill_line(&mut self.input_listener);
                 }
-                Key::Ctrl('w') => {
+                key if keybinds.remove_previous_word.contains(key) => {
                     self.input
                         .delete_prev_word(Word::Emacs, 1, &mut self.input_listener);
                 }
@@ -259,14 +259,16 @@ impl<T: Clone> Component for InputWidget<T> {
                 Key::Backspace => {
                     self.input.backspace(1, &mut self.input_listener);
                 }
-                Key::Tab => {
+                key if keybinds.fill_suggestion.contains(key) => {
                     if let Some(suggestion) = &self.suggestion {
                         self.input
                             .update(suggestion, suggestion.len(), &mut self.input_listener);
                     }
                 }
-                Key::Ctrl('p') => panic!("Manual panic triggered by user."),
-                Key::Ctrl('q') => return Some(TerminalAction::Quit),
+                key if keybinds.crash_application.contains(key) => {
+                    panic!("Manual panic triggered by user.")
+                }
+                key if keybinds.quit.contains(key) => return Some(TerminalAction::Quit),
                 Key::Char(c) => {
                     self.input.insert(*c, 1, &mut self.input_listener);
                 }

--- a/src/ui/components/utils/input_widget.rs
+++ b/src/ui/components/utils/input_widget.rs
@@ -211,8 +211,10 @@ impl<T: Clone> Component for InputWidget<T> {
 
     async fn event(&mut self, event: &Event) -> Option<TerminalAction> {
         if let Event::Input(key) = event {
+            //TODO idk if this needs to be cloned or not
+            let keybinds = self.config.borrow().keybinds.insert.clone();
             match key {
-                Key::Ctrl('f') | Key::Right => {
+                key if keybinds.move_cursor_right.contains(key) => {
                     if self.input.next_pos(1).is_none() {
                         self.accept_suggestion();
                         self.input.move_end();
@@ -220,16 +222,16 @@ impl<T: Clone> Component for InputWidget<T> {
                         self.input.move_forward(1);
                     }
                 }
-                Key::Ctrl('b') | Key::Left => {
+                key if keybinds.move_cursor_left.contains(key) => {
                     self.input.move_backward(1);
                 }
-                Key::Ctrl('a') | Key::Home => {
+                key if keybinds.move_cursor_start.contains(key) => {
                     self.input.move_home();
                 }
-                Key::Ctrl('e') | Key::End => {
+                key if keybinds.move_cursor_end.contains(key) => {
                     self.input.move_end();
                 }
-                Key::Alt('f') => {
+                key if keybinds.end_of_next_word.contains(key) => {
                     self.input.move_to_next_word(At::AfterEnd, Word::Emacs, 1);
                 }
                 Key::Alt('b') => {
@@ -251,7 +253,7 @@ impl<T: Clone> Component for InputWidget<T> {
                     self.input
                         .delete_prev_word(Word::Emacs, 1, &mut self.input_listener);
                 }
-                Key::Ctrl('d') | Key::Delete => {
+                key if keybinds.remove_item_to_right.contains(key) => {
                     self.input.delete(1, &mut self.input_listener);
                 }
                 Key::Backspace => {

--- a/src/ui/components/utils/search_widget.rs
+++ b/src/ui/components/utils/search_widget.rs
@@ -273,8 +273,8 @@ where
                         self.toggle_focus().await;
                     }
                 }
-                key if keybinds.scroll_down.contains(key) => self.next(),
-                key if keybinds.scroll_up.contains(key) => self.previous(),
+                key if keybinds.next_item.contains(key) => self.next(),
+                key if keybinds.prev_item.contains(key) => self.previous(),
                 key if keybinds.select.contains(key) => {
                     if let Some(i) = self.list_state.selected() {
                         let selected_channel = if let Some(v) = self.filtered_items.clone() {

--- a/src/ui/components/utils/search_widget.rs
+++ b/src/ui/components/utils/search_widget.rs
@@ -264,17 +264,18 @@ where
         }
 
         if let Event::Input(key) = event {
+            let keybinds = self.config.borrow().keybinds.selection.clone();
             match key {
-                Key::Esc => {
+                key if keybinds.back_to_previous_window.contains(key) => {
                     if self.list_state.selected().is_some() {
                         self.unselect();
                     } else {
                         self.toggle_focus().await;
                     }
                 }
-                Key::ScrollDown | Key::Down => self.next(),
-                Key::ScrollUp | Key::Up => self.previous(),
-                Key::Enter => {
+                key if keybinds.scroll_down.contains(key) => self.next(),
+                key if keybinds.scroll_up.contains(key) => self.previous(),
+                key if keybinds.select.contains(key) => {
                     if let Some(i) = self.list_state.selected() {
                         let selected_channel = if let Some(v) = self.filtered_items.clone() {
                             if v.is_empty() {

--- a/src/ui/components/utils/search_widget.rs
+++ b/src/ui/components/utils/search_widget.rs
@@ -64,7 +64,7 @@ where
 {
     pub fn new(config: SharedCoreConfig, item_getter: U, error_message: Vec<&'static str>) -> Self {
         let search_input = InputWidget::new(config.clone(), "Search", None, None, None);
-        let error_widget = ErrorWidget::new(error_message);
+        let error_widget = ErrorWidget::new(config.clone(), error_message);
 
         Self {
             config,

--- a/src/ui/statics.rs
+++ b/src/ui/statics.rs
@@ -3,60 +3,6 @@ use std::sync::LazyLock;
 pub static HELP_COLUMN_TITLES: LazyLock<Vec<&str>> =
     LazyLock::new(|| vec!["State", "Keybind", "Description"]);
 
-type KeybindPair<'a> = Vec<(&'a str, &'a str)>;
-
-pub static HELP_KEYBINDS: LazyLock<Vec<(&str, KeybindPair)>> = LazyLock::new(|| {
-    let dashboard_keybinds = vec![
-        ("Enter", "Join the selected channel"),
-        ("? or h", "Have the keybinds popup window appear"),
-        ("q", "Quit the application"),
-        ("s", "Open the recent channel search popup"),
-        ("f", "Open the followed channel search popup"),
-        ("Ctrl + p", "Manually crash the application"),
-    ];
-    let normal_keybinds = vec![
-        ("i or c", "Enter message (chat) mode for sending messages"),
-        ("@", "Messaging mode with mention symbol"),
-        ("/", "Messaging mode with command symbol"),
-        ("? or h", "* You are here!"),
-        ("q", "Quit the application"),
-        ("s", "Open the recent channel search widget"),
-        ("f", "Open the followed channel search widget"),
-        ("S", "Go to the dashboard screen (start screen)"),
-        ("Ctrl + f", "Search messages"),
-        ("Ctrl + t", "Toggle the message filter"),
-        ("Ctrl + r", "Reverse the message filter"),
-        ("Ctrl + p", "Manually crash the application"),
-        ("Esc", "Go back to the previous window"),
-    ];
-    let insert_keybinds = vec![
-        ("Tab", "Fill in suggestion, if available"),
-        ("Enter", "Confirm the input text to go through"),
-        ("Esc", "Go back to the previous window"),
-        ("Ctrl + f", "Move cursor to the right"),
-        ("Ctrl + b", "Move cursor to the left"),
-        ("Ctrl + a", "Move cursor to the start"),
-        ("Ctrl + e", "Move cursor to the end"),
-        ("Ctrl + t", "Swap previous item with current item"),
-        ("Ctrl + k", "Remove everything after the cursor"),
-        ("Ctrl + u", "Remove everything before the cursor"),
-        ("Ctrl + w", "Remove the previous word"),
-        ("Ctrl + d", "Remove item to the right"),
-        ("Ctrl + t", "Toggle the filter"),
-        ("Ctrl + r", "Reverse the filter"),
-        ("Alt + f", "Move to the end of the next word"),
-        ("Alt + b", "Move to the start of the previous word"),
-        ("Alt + t", "Swap previous word with current word"),
-        ("Alt + e", "Toggle emote picker"),
-    ];
-
-    vec![
-        ("Dashboard", dashboard_keybinds),
-        ("Normal mode", normal_keybinds),
-        ("Insert modes", insert_keybinds),
-    ]
-});
-
 // https://help.twitch.tv/s/article/chat-commands?language=en_US
 pub static SUPPORTED_COMMANDS: LazyLock<Vec<&str>> = LazyLock::new(|| {
     vec![


### PR DESCRIPTION
resolves #362

following things to be addressed:

### serialization/deserialization
ive just used the derive for now, but it definitely should be something that's more customizable deserialized, i imagine its best to match the current output format when it comes to the help page but im not sure

### help page
speaking of which, the help page also does need to support outputting these new keybinds, i dont think that should be too difficult but yeah

### default components
so even though most components have access to the config in some way, the default impl of the components event isnt able to use that, so i dont know whats the best way to do that, it could either be impling manually or adding another thing to get the config refcell but either way might be awkward so not sure about this one, 

### match style
right now im using a bunch of match guards, but idk if thats preferred over if else chains, there's probably the option of making an impl to convert it to an action but idk whats best here
