### PR TITLE
make content classification table null instead of empty

### DIFF
--- a/src/twitch/api/channel_information.rs
+++ b/src/twitch/api/channel_information.rs
@@ -50,7 +50,7 @@ pub struct UpdateChannelInformationPayload {
     title: Option<String>,
     delay: Option<usize>,
     tags: Option<Vec<String>>,
-    content_classification_labels: Vec<ChannelInformationLabel>,
+    content_classification_labels: Option<Vec<ChannelInformationLabel>>,
     is_branded_content: Option<bool>,
 }
 


### PR DESCRIPTION
i think this changed in some update? i feel like it used to work but now it doesn't, either way this fixes it,